### PR TITLE
feat: add multi-subject notes interface

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -1,9 +1,118 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, ScrollView, TouchableOpacity, Modal, TextInput, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+
+type Subject = {
+  key: string;
+  title: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  note: string;
+  color: string;
+  image: string | null;
+};
+
+const initialSubjects: Subject[] = [
+  { key: 'math', title: 'Math', icon: 'calculator', note: '', color: '#3b2e7e', image: null },
+  { key: 'science', title: 'Science', icon: 'flask', note: '', color: '#3b2e7e', image: null },
+  { key: 'history', title: 'History', icon: 'book', note: '', color: '#3b2e7e', image: null },
+  { key: 'language', title: 'Language', icon: 'globe-outline', note: '', color: '#3b2e7e', image: null },
+];
 
 export default function NotesScreen() {
+  const [subjects, setSubjects] = useState<Subject[]>(initialSubjects);
+  const [active, setActive] = useState<Subject | null>(null);
+
+  const openSubject = (subject: Subject) => setActive(subject);
+
+  const closeSubject = () => setActive(null);
+
+  const updateSubject = (updated: Subject) => {
+    setSubjects(prev => prev.map(s => (s.key === updated.key ? updated : s)));
+  };
+
+  const pickImage = async (subject: Subject) => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 1,
+    });
+
+    if (!result.canceled && result.assets.length > 0) {
+      const updated = { ...subject, image: result.assets[0].uri };
+      setActive(updated);
+      updateSubject(updated);
+    }
+  };
+
+  const colorOptions = ['#3b2e7e', '#6a0dad', '#1a1a40', '#2e1065'];
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>📝 Notes Screen</Text>
+      <ScrollView contentContainerStyle={styles.grid}>
+        {subjects.map(subject => (
+          <TouchableOpacity
+            key={subject.key}
+            style={[styles.box, { backgroundColor: subject.color }]}
+            onPress={() => openSubject(subject)}
+          >
+            <Ionicons name={subject.icon} size={32} color="#dcd6f7" />
+            <Text style={styles.boxTitle}>{subject.title}</Text>
+            {subject.image && <Image source={{ uri: subject.image }} style={styles.thumbnail} />}
+            {subject.note ? (
+              <Text numberOfLines={2} style={styles.boxNote}>
+                {subject.note}
+              </Text>
+            ) : null}
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+
+      <Modal visible={!!active} animationType="slide">
+        {active && (
+          <View style={styles.modalContainer}>
+            <View style={[styles.modalHeader, { backgroundColor: active.color }]}>
+              <Ionicons name={active.icon} size={28} color="#dcd6f7" />
+              <Text style={styles.modalTitle}>{active.title}</Text>
+            </View>
+            <ScrollView contentContainerStyle={styles.modalContent}>
+              <TextInput
+                style={styles.input}
+                placeholder="Write your note..."
+                placeholderTextColor="#999"
+                multiline
+                value={active.note}
+                onChangeText={text => {
+                  const updated = { ...active, note: text };
+                  setActive(updated);
+                  updateSubject(updated);
+                }}
+              />
+              {active.image && <Image source={{ uri: active.image }} style={styles.image} />}
+              <View style={styles.colorRow}>
+                {colorOptions.map(c => (
+                  <TouchableOpacity
+                    key={c}
+                    style={[styles.colorSwatch, { backgroundColor: c }]}
+                    onPress={() => {
+                      const updated = { ...active, color: c };
+                      setActive(updated);
+                      updateSubject(updated);
+                    }}
+                  />
+                ))}
+              </View>
+              <TouchableOpacity style={styles.imageButton} onPress={() => pickImage(active)}>
+                <Ionicons name="image" size={20} color="#dcd6f7" />
+                <Text style={styles.imageButtonText}>Add Image</Text>
+              </TouchableOpacity>
+            </ScrollView>
+            <TouchableOpacity style={styles.closeButton} onPress={closeSubject}>
+              <Text style={styles.closeButtonText}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </Modal>
     </View>
   );
 }
@@ -11,12 +120,97 @@ export default function NotesScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1c1c1c',
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: '#0d0d3d',
+    padding: 16,
   },
-  text: {
-    fontSize: 22,
-    color: '#f4d03f',
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  box: {
+    width: '48%',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  boxTitle: {
+    marginTop: 8,
+    color: '#dcd6f7',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  boxNote: {
+    marginTop: 8,
+    color: '#e0e0e0',
+    fontSize: 14,
+  },
+  thumbnail: {
+    width: '100%',
+    height: 80,
+    marginTop: 8,
+    borderRadius: 8,
+  },
+  modalContainer: {
+    flex: 1,
+    backgroundColor: '#0d0d3d',
+  },
+  modalHeader: {
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  modalTitle: {
+    marginLeft: 8,
+    color: '#dcd6f7',
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  modalContent: {
+    padding: 16,
+  },
+  input: {
+    minHeight: 120,
+    borderColor: '#2e1065',
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    color: '#dcd6f7',
+    textAlignVertical: 'top',
+  },
+  image: {
+    width: '100%',
+    height: 200,
+    marginTop: 16,
+    borderRadius: 8,
+  },
+  imageButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  imageButtonText: {
+    marginLeft: 8,
+    color: '#dcd6f7',
+  },
+  colorRow: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  colorSwatch: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    marginRight: 8,
+  },
+  closeButton: {
+    backgroundColor: '#2e1065',
+    padding: 16,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#dcd6f7',
+    fontSize: 16,
+    fontWeight: 'bold',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
+        "expo-image-picker": "~16.1.4",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.5",
         "expo-splash-screen": "~0.30.10",
@@ -6242,6 +6243,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
+    "expo-image-picker": "~16.1.4",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-splash-screen": "~0.30.10",
@@ -41,9 +42,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "typescript": "~5.8.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- organize notes into subject-specific boxes with icons and purple/blue theme
- enable editing each subject's notes with color selection and image attachments
- add expo-image-picker dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c387bfb08329ae842bd2b8bfa4ab