### PR TITLE
Enable images in notes and customizable section colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
         "expo-image-picker": "~16.1.4",
+        "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.5",
         "expo-splash-screen": "~0.30.10",
@@ -6274,6 +6275,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "14.1.5",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-14.1.5.tgz",
+      "integrity": "sha512-BSN3MkSGLZoHMduEnAgfhoj3xqcDWaoICgIr4cIYEx1GcHfKMhzA/O4mpZJ/WC27BP1rnAqoKfbclk1eA70ndQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
     "expo-image-picker": "~16.1.4",
+    "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-splash-screen": "~0.30.10",


### PR DESCRIPTION
## Summary
- allow attaching images to individual notes
- add color palette to change subject section color and apply gradient background
- tidy layout spacing and alignment for professional appearance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0cfbd116c8329ac98c1c73757cf80