### PR TITLE
fix: restore text formatting and highlight

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -375,18 +375,23 @@ export default function NotesScreen() {
               />
               <RichToolbar
                 editor={richText}
-                actions={[actions.bold, actions.italic, actions.underline, 'highlight']}
+                actions={[
+                  actions.setBold,
+                  actions.setItalic,
+                  actions.setUnderline,
+                  actions.hiliteColor,
+                ]}
                 iconTint={iconColor}
                 selectedIconTint={iconColor}
                 style={styles.formatBar}
                 iconMap={{
-                  highlight: ({ tintColor }) => (
+                  [actions.hiliteColor]: ({ tintColor }) => (
                     <Ionicons name="color-fill" size={20} color={tintColor} />
                   ),
                 }}
                 onPress={action => {
-                  if (action === 'highlight') {
-                    richText.current?.commandExecutor('hiliteColor', '#ffeb3b');
+                  if (action === actions.hiliteColor) {
+                    richText.current?.setHiliteColor('#ffeb3b');
                   }
                 }}
               />


### PR DESCRIPTION
## Summary
- restore bold and italic toolbar actions
- fix highlight action by using setHiliteColor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unable to resolve path to module 'react-native-pell-rich-editor')*

------
https://chatgpt.com/codex/tasks/task_e_68b0f54561008329aba8b5e73e3e0da6