### PR TITLE
Add floating Siri-style AI assistant button

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved */
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import {
   StyleSheet,
   Text,
@@ -10,8 +10,6 @@ import {
   Alert,
   TextInput,
   useWindowDimensions,
-  Animated,
-  Easing,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
@@ -19,7 +17,7 @@ import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { RichEditor, RichToolbar, actions } from 'react-native-pell-rich-editor';
 import RenderHTML from 'react-native-render-html';
-import { router } from 'expo-router';
+import AIButton from '../../components/AIButton';
 
 type Note = {
   id: string;
@@ -77,18 +75,6 @@ export default function NotesScreen() {
   const iconColor = textColor;
   const richText = useRef<RichEditor>(null);
   const { width } = useWindowDimensions();
-  const aiAnim = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    Animated.loop(
-      Animated.timing(aiAnim, {
-        toValue: 1,
-        duration: 2000,
-        easing: Easing.linear,
-        useNativeDriver: true,
-      }),
-    ).start();
-  }, [aiAnim]);
 
   const stripHtml = (html: string) => html.replace(/<[^>]+>/g, '');
   const filteredNotes = useMemo(
@@ -293,6 +279,8 @@ export default function NotesScreen() {
         />
       </TouchableOpacity>
 
+      <AIButton />
+
       <Modal visible={!!active} animationType="slide">
         {active && (
           <View style={styles.modalContainer}>
@@ -366,6 +354,7 @@ export default function NotesScreen() {
             <TouchableOpacity style={styles.closeButton} onPress={closeSubject}>
               <Text style={styles.closeButtonText}>Close</Text>
             </TouchableOpacity>
+            <AIButton />
           </View>
         )}
       </Modal>
@@ -462,27 +451,7 @@ export default function NotesScreen() {
                 </TouchableOpacity>
               </View>
             </ScrollView>
-            <TouchableOpacity
-              style={styles.aiButton}
-              onPress={() => router.push('/tutor')}
-            >
-              <Animated.Image
-                source={require('../../assets/images/splash-icon.png')}
-                style={[
-                  styles.aiIcon,
-                  {
-                    transform: [
-                      {
-                        rotate: aiAnim.interpolate({
-                          inputRange: [0, 1],
-                          outputRange: ['0deg', '360deg'],
-                        }),
-                      },
-                    ],
-                  },
-                ]}
-              />
-            </TouchableOpacity>
+            <AIButton />
           </View>
         )}
       </Modal>
@@ -740,15 +709,6 @@ const createStyles = (dark: boolean) => {
       borderRadius: 12,
       borderWidth: 2,
       borderColor: textColor,
-    },
-    aiButton: {
-      position: 'absolute',
-      bottom: 20,
-      alignSelf: 'center',
-    },
-    aiIcon: {
-      width: 70,
-      height: 70,
     },
     imageIconContainer: {
       width: 30,

--- a/components/AIButton.tsx
+++ b/components/AIButton.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from 'react';
+import { TouchableOpacity, Animated, Easing, StyleSheet } from 'react-native';
+import { router } from 'expo-router';
+import SiriIcon from './SiriIcon';
+
+export default function AIButton() {
+  const float = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(float, {
+          toValue: -8,
+          duration: 3000,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(float, {
+          toValue: 0,
+          duration: 3000,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [float]);
+
+  return (
+    <Animated.View style={[styles.container, { transform: [{ translateY: float }] }]}>
+      <TouchableOpacity onPress={() => router.push('/tutor')}>
+        <SiriIcon />
+      </TouchableOpacity>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 20,
+    alignSelf: 'center',
+  },
+});
+

--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+interface Props {
+  size?: number;
+}
+
+export default function SiriIcon({ size = 70 }: Props) {
+  return (
+    <View
+      style={[
+        styles.container,
+        { width: size, height: size, borderRadius: size / 2 },
+      ]}
+    >
+      <LinearGradient
+        colors={['#5ac8fa', '#5856d6']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={['#ff2d55', '#ff9500']}
+        start={{ x: 1, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        style={[
+          StyleSheet.absoluteFill,
+          { opacity: 0.7, transform: [{ rotate: '60deg' }] },
+        ]}
+      />
+      <LinearGradient
+        colors={['#4cd964', '#007aff']}
+        start={{ x: 0, y: 1 }}
+        end={{ x: 1, y: 0 }}
+        style={[
+          StyleSheet.absoluteFill,
+          { opacity: 0.7, transform: [{ rotate: '-60deg' }] },
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    overflow: 'hidden',
+  },
+});
+


### PR DESCRIPTION
## Summary
- create reusable SiriIcon and AIButton components with gentle hover animation
- show floating AI button on notes screen, subject sections, and note editor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b103fce1d08329a898832b195ad926