### PR TITLE
Refine AI icon design and placement

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -354,7 +354,7 @@ export default function NotesScreen() {
             <TouchableOpacity style={styles.closeButton} onPress={closeSubject}>
               <Text style={styles.closeButtonText}>Close</Text>
             </TouchableOpacity>
-            <AIButton />
+            <AIButton bottomOffset={100} />
           </View>
         )}
       </Modal>
@@ -451,7 +451,7 @@ export default function NotesScreen() {
                 </TouchableOpacity>
               </View>
             </ScrollView>
-            <AIButton />
+            <AIButton bottomOffset={100} />
           </View>
         )}
       </Modal>

--- a/components/AIButton.tsx
+++ b/components/AIButton.tsx
@@ -3,7 +3,12 @@ import { TouchableOpacity, Animated, Easing, StyleSheet } from 'react-native';
 import { router } from 'expo-router';
 import SiriIcon from './SiriIcon';
 
-export default function AIButton() {
+interface Props {
+  bottomOffset?: number;
+  size?: number;
+}
+
+export default function AIButton({ bottomOffset = 20, size }: Props) {
   const float = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -26,9 +31,14 @@ export default function AIButton() {
   }, [float]);
 
   return (
-    <Animated.View style={[styles.container, { transform: [{ translateY: float }] }]}>
+    <Animated.View
+      style={[
+        styles.container,
+        { transform: [{ translateY: float }], bottom: bottomOffset },
+      ]}
+    >
       <TouchableOpacity onPress={() => router.push('/tutor')}>
-        <SiriIcon />
+        <SiriIcon size={size} />
       </TouchableOpacity>
     </Animated.View>
   );
@@ -37,7 +47,6 @@ export default function AIButton() {
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    bottom: 20,
     alignSelf: 'center',
   },
 });

--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -6,7 +6,7 @@ interface Props {
   size?: number;
 }
 
-export default function SiriIcon({ size = 70 }: Props) {
+export default function SiriIcon({ size = 60 }: Props) {
   return (
     <View
       style={[
@@ -38,6 +38,21 @@ export default function SiriIcon({ size = 70 }: Props) {
           { opacity: 0.7, transform: [{ rotate: '-60deg' }] },
         ]}
       />
+      <LinearGradient
+        colors={['rgba(255,255,255,0.8)', 'rgba(255,255,255,0)']}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        style={[
+          StyleSheet.absoluteFill,
+          { opacity: 0.6 },
+        ]}
+      />
+      <View
+        style={[
+          styles.innerRing,
+          { borderRadius: (size - 4) / 2 },
+        ]}
+      />
     </View>
   );
 }
@@ -45,6 +60,15 @@ export default function SiriIcon({ size = 70 }: Props) {
 const styles = StyleSheet.create({
   container: {
     overflow: 'hidden',
+  },
+  innerRing: {
+    position: 'absolute',
+    top: 2,
+    left: 2,
+    right: 2,
+    bottom: 2,
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.5)',
   },
 });
 


### PR DESCRIPTION
## Summary
- Rework Siri-style AI icon with smaller size, highlight, and inner ring for a shinier look
- Allow AI button size and bottom offset customization
- Move AI button in notes modals away from Close controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b106614d2083299752ef7bd85aa325