### PR TITLE
feat: redesign AI icon with notebook watermark

### DIFF
--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -1,58 +1,59 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import { View, StyleSheet, Text } from 'react-native';
 
 interface Props {
   size?: number;
 }
 
 export default function SiriIcon({ size = 60 }: Props) {
+  const notebookSize = size * 0.6;
+  const border = size * 0.03;
+  const lineHeight = size * 0.02;
+
   return (
     <View
       style={[
         styles.container,
-        { width: size, height: size, borderRadius: size / 2 },
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: '#003366',
+        },
       ]}
     >
-      <LinearGradient
-        colors={['#5ac8fa', '#5856d6']}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={StyleSheet.absoluteFill}
-      />
-      <LinearGradient
-        colors={['#ff2d55', '#ff9500']}
-        start={{ x: 1, y: 0 }}
-        end={{ x: 0, y: 1 }}
-        style={[
-          StyleSheet.absoluteFill,
-          { opacity: 0.7, transform: [{ rotate: '60deg' }] },
-        ]}
-      />
-      <LinearGradient
-        colors={['#4cd964', '#007aff']}
-        start={{ x: 0, y: 1 }}
-        end={{ x: 1, y: 0 }}
-        style={[
-          StyleSheet.absoluteFill,
-          { opacity: 0.7, transform: [{ rotate: '-60deg' }] },
-        ]}
-      />
-      <LinearGradient
-        colors={['rgba(255,255,255,0.8)', 'rgba(255,255,255,0)']}
-        start={{ x: 0.5, y: 0 }}
-        end={{ x: 0.5, y: 1 }}
-        style={[
-          StyleSheet.absoluteFill,
-          { opacity: 0.6 },
-        ]}
-      />
       <View
         style={[
-          styles.innerRing,
-          { borderRadius: (size - 4) / 2 },
+          styles.notebook,
+          {
+            width: notebookSize,
+            height: notebookSize,
+            borderRadius: size * 0.05,
+            borderWidth: border,
+          },
         ]}
-      />
+      >
+        <View
+          style={[
+            styles.line,
+            { top: notebookSize * 0.3, height: lineHeight, borderRadius: lineHeight / 2 },
+          ]}
+        />
+        <View
+          style={[
+            styles.line,
+            { top: notebookSize * 0.55, height: lineHeight, borderRadius: lineHeight / 2 },
+          ]}
+        />
+        <Text
+          style={[
+            styles.watermark,
+            { fontSize: size * 0.15, top: -size * 0.08, right: -size * 0.08 },
+          ]}
+        >
+          AI
+        </Text>
+      </View>
     </View>
   );
 }
@@ -60,15 +61,24 @@ export default function SiriIcon({ size = 60 }: Props) {
 const styles = StyleSheet.create({
   container: {
     overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  innerRing: {
+  notebook: {
+    position: 'relative',
+    backgroundColor: '#ffffff',
+    borderColor: '#000080',
+  },
+  line: {
     position: 'absolute',
-    top: 2,
-    left: 2,
-    right: 2,
-    bottom: 2,
-    borderWidth: 2,
-    borderColor: 'rgba(255,255,255,0.5)',
+    left: '5%',
+    right: '5%',
+    backgroundColor: '#000080',
+  },
+  watermark: {
+    position: 'absolute',
+    color: '#000080',
+    fontWeight: 'bold',
   },
 });
 


### PR DESCRIPTION
## Summary
- Replace Siri-inspired gradients with a dark blue circular background
- Draw a simple notebook vector and add an "AI" watermark in the icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b108159c508329adeee693264d822a