### PR TITLE
Refine SiriIcon colors and add light mode inversion

### DIFF
--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, Text } from 'react-native';
+import { View, StyleSheet, Text, useColorScheme } from 'react-native';
 
 interface Props {
   size?: number;
@@ -9,6 +9,14 @@ export default function SiriIcon({ size = 60 }: Props) {
   const notebookSize = size * 0.6;
   const border = size * 0.03;
   const lineHeight = size * 0.02;
+  const isDarkMode = useColorScheme() === 'dark';
+
+  const containerColor = isDarkMode ? '#4a90e2' : '#b5d1ff';
+  const notebookBackground = isDarkMode ? '#f2f2f2' : '#333333';
+  const borderColor = isDarkMode ? '#000000' : '#ffffff';
+  const lineColor = borderColor;
+  const watermarkColor = isDarkMode ? '#ffffff' : '#000000';
+  const watermarkOutline = isDarkMode ? '#000000' : '#ffffff';
 
   return (
     <View
@@ -18,7 +26,7 @@ export default function SiriIcon({ size = 60 }: Props) {
           width: size,
           height: size,
           borderRadius: size / 2,
-          backgroundColor: '#003366',
+          backgroundColor: containerColor,
         },
       ]}
     >
@@ -30,25 +38,45 @@ export default function SiriIcon({ size = 60 }: Props) {
             height: notebookSize,
             borderRadius: size * 0.05,
             borderWidth: border,
+            backgroundColor: notebookBackground,
+            borderColor: borderColor,
           },
         ]}
       >
         <View
           style={[
             styles.line,
-            { top: notebookSize * 0.3, height: lineHeight, borderRadius: lineHeight / 2 },
+            {
+              top: notebookSize * 0.3,
+              height: lineHeight,
+              borderRadius: lineHeight / 2,
+              backgroundColor: lineColor,
+            },
           ]}
         />
         <View
           style={[
             styles.line,
-            { top: notebookSize * 0.55, height: lineHeight, borderRadius: lineHeight / 2 },
+            {
+              top: notebookSize * 0.55,
+              height: lineHeight,
+              borderRadius: lineHeight / 2,
+              backgroundColor: lineColor,
+            },
           ]}
         />
         <Text
           style={[
             styles.watermark,
-            { fontSize: size * 0.15, top: -size * 0.08, right: -size * 0.08 },
+            {
+              fontSize: size * 0.15,
+              top: -size * 0.08,
+              right: -size * 0.08,
+              color: watermarkColor,
+              textShadowColor: watermarkOutline,
+              textShadowOffset: { width: 1, height: 1 },
+              textShadowRadius: 1,
+            },
           ]}
         >
           AI
@@ -66,18 +94,14 @@ const styles = StyleSheet.create({
   },
   notebook: {
     position: 'relative',
-    backgroundColor: '#ffffff',
-    borderColor: '#000080',
   },
   line: {
     position: 'absolute',
     left: '5%',
     right: '5%',
-    backgroundColor: '#000080',
   },
   watermark: {
     position: 'absolute',
-    color: '#000080',
     fontWeight: 'bold',
   },
 });


### PR DESCRIPTION
## Summary
- Lighten SiriIcon background blue
- Use grayish-white notebook and invert styles for light mode
- Outline "AI" text and flip colors by color scheme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1097e67b08329a77d961fc6d35eae