### PR TITLE
Remove dark mode and add animated home tab

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,20 +1,45 @@
 import { Tabs } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, Animated } from 'react-native';
 
 import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
 
-export default function TabLayout() {
-  const colorScheme = useColorScheme();
+// Animated icon for the Tutor tab.
+function TutorIcon({ color, focused }: { color: string; focused: boolean }) {
+  const scale = React.useRef(new Animated.Value(1)).current;
+
+  React.useEffect(() => {
+    if (focused) {
+      Animated.sequence([
+        Animated.timing(scale, {
+          toValue: 1.2,
+          duration: 100,
+          useNativeDriver: true,
+        }),
+        Animated.spring(scale, {
+          toValue: 1,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [focused, scale]);
 
   return (
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <MaterialIcons size={28} name="school" color={color} />
+    </Animated.View>
+  );
+}
+
+export default function TabLayout() {
+  return (
     <Tabs
+      initialRouteName="home"
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: Colors.light.tint,
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
@@ -45,11 +70,20 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="home"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons size={28} name="home" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="tutor"
         options={{
           title: 'Tutor',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} name="school" color={color} />
+          tabBarIcon: ({ color, focused }) => (
+            <TutorIcon color={color} focused={focused} />
           ),
         }}
       />

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,0 +1,22 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Home</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});

--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -68,10 +68,9 @@ export default function NotesScreen() {
   const [currentNote, setCurrentNote] = useState<Note | null>(null);
   const [showSubjectColors, setShowSubjectColors] = useState(false);
   const [showNoteColors, setShowNoteColors] = useState(false);
-  const [darkMode, setDarkMode] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
-  const styles = useMemo(() => createStyles(darkMode), [darkMode]);
-  const textColor = darkMode ? '#dcd6f7' : '#000';
+  const styles = useMemo(() => createStyles(), []);
+  const textColor = '#000';
   const iconColor = textColor;
   const richText = useRef<RichEditor>(null);
   const { width } = useWindowDimensions();
@@ -212,11 +211,7 @@ export default function NotesScreen() {
 
   return (
     <LinearGradient
-      colors={
-        darkMode
-          ? ['#0d0d3d', '#1a1a40', '#3b2e7e', '#6a0dad']
-          : ['#cde7ff', '#b7d9ff', '#9ccaff', '#b7d9ff']
-      }
+      colors={['#cde7ff', '#b7d9ff', '#9ccaff', '#b7d9ff']}
       style={styles.container}
     >
       <Text style={styles.title}>NOTES</Text>
@@ -268,17 +263,6 @@ export default function NotesScreen() {
           ))}
         </ScrollView>
       )}
-      <TouchableOpacity
-        style={styles.themeToggle}
-        onPress={() => setDarkMode(!darkMode)}
-      >
-        <Ionicons
-          name={darkMode ? 'moon' : 'sunny'}
-          size={24}
-          color={iconColor}
-        />
-      </TouchableOpacity>
-
       <AIButton />
 
       <Modal visible={!!active} animationType="slide">
@@ -459,14 +443,14 @@ export default function NotesScreen() {
   );
 }
 
-const createStyles = (dark: boolean) => {
-  const textColor = dark ? '#dcd6f7' : '#000';
-  const secondaryText = dark ? '#e0e0e0' : '#333';
-  const background = dark ? '#0d0d3d' : '#cde7ff';
-  const toggleBg = dark ? '#1a1a40' : '#b7d9ff';
-  const inputBorder = dark ? '#2e1065' : '#99c1ff';
-  const selectedBorder = dark ? '#fff' : '#000';
-  const cancelBg = dark ? '#6c757d' : '#b0c4de';
+const createStyles = () => {
+  const textColor = '#000';
+  const secondaryText = '#333';
+  const background = '#cde7ff';
+  const toggleBg = '#b7d9ff';
+  const inputBorder = '#99c1ff';
+  const selectedBorder = '#000';
+  const cancelBg = '#b0c4de';
   return StyleSheet.create({
     container: {
       flex: 1,
@@ -686,17 +670,6 @@ const createStyles = (dark: boolean) => {
     saveButtonText: {
       color: textColor,
       fontSize: 16,
-    },
-    themeToggle: {
-      position: 'absolute',
-      bottom: 30,
-      right: 20,
-      width: 60,
-      height: 60,
-      borderRadius: 30,
-      backgroundColor: toggleBg,
-      justifyContent: 'center',
-      alignItems: 'center',
     },
     colorToggle: {
       flexDirection: 'row',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,10 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
-import { useColorScheme } from '@/hooks/useColorScheme';
-
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
@@ -18,12 +15,12 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
-      <StatusBar style="auto" />
+      <StatusBar style="dark" />
     </ThemeProvider>
   );
 }

--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -5,11 +5,9 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const theme = useColorScheme() ?? 'light';
 
   return (
     <ThemedView>
@@ -21,7 +19,7 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
           name="chevron.right"
           size={18}
           weight="medium"
-          color={theme === 'light' ? Colors.light.icon : Colors.dark.icon}
+          color={Colors.light.icon}
           style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
         />
 

--- a/components/ParallaxScrollView.tsx
+++ b/components/ParallaxScrollView.tsx
@@ -9,13 +9,12 @@ import Animated, {
 
 import { ThemedView } from '@/components/ThemedView';
 import { useBottomTabOverflow } from '@/components/ui/TabBarBackground';
-import { useColorScheme } from '@/hooks/useColorScheme';
 
 const HEADER_HEIGHT = 250;
 
 type Props = PropsWithChildren<{
   headerImage: ReactElement;
-  headerBackgroundColor: { dark: string; light: string };
+  headerBackgroundColor: string;
 }>;
 
 export default function ParallaxScrollView({
@@ -23,7 +22,6 @@ export default function ParallaxScrollView({
   headerImage,
   headerBackgroundColor,
 }: Props) {
-  const colorScheme = useColorScheme() ?? 'light';
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollViewOffset(scrollRef);
   const bottom = useBottomTabOverflow();
@@ -54,7 +52,7 @@ export default function ParallaxScrollView({
         <Animated.View
           style={[
             styles.header,
-            { backgroundColor: headerBackgroundColor[colorScheme] },
+            { backgroundColor: headerBackgroundColor },
             headerAnimatedStyle,
           ]}>
           {headerImage}

--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, Text, useColorScheme } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
 
 interface Props {
   size?: number;
@@ -9,14 +9,13 @@ export default function SiriIcon({ size = 60 }: Props) {
   const notebookSize = size * 0.6;
   const border = size * 0.03;
   const lineHeight = size * 0.02;
-  const isDarkMode = useColorScheme() === 'dark';
 
-  const containerColor = isDarkMode ? '#4a90e2' : '#b5d1ff';
-  const notebookBackground = isDarkMode ? '#f2f2f2' : '#333333';
-  const borderColor = isDarkMode ? '#000000' : '#ffffff';
+  const containerColor = '#b5d1ff';
+  const notebookBackground = '#333333';
+  const borderColor = '#ffffff';
   const lineColor = borderColor;
-  const watermarkColor = isDarkMode ? '#ffffff' : '#000000';
-  const watermarkOutline = isDarkMode ? '#000000' : '#ffffff';
+  const watermarkColor = '#000000';
+  const watermarkOutline = '#ffffff';
 
   return (
     <View

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -4,18 +4,16 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
-  darkColor?: string;
   type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
 };
 
 export function ThemedText({
   style,
   lightColor,
-  darkColor,
   type = 'default',
   ...rest
 }: ThemedTextProps) {
-  const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+  const color = useThemeColor({ light: lightColor }, 'text');
 
   return (
     <Text

--- a/components/ThemedView.tsx
+++ b/components/ThemedView.tsx
@@ -4,11 +4,10 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 
 export type ThemedViewProps = ViewProps & {
   lightColor?: string;
-  darkColor?: string;
 };
 
-export function ThemedView({ style, lightColor, darkColor, ...otherProps }: ThemedViewProps) {
-  const backgroundColor = useThemeColor({ light: lightColor, dark: darkColor }, 'background');
+export function ThemedView({ style, lightColor, ...otherProps }: ThemedViewProps) {
+  const backgroundColor = useThemeColor({ light: lightColor }, 'background');
 
   return <View style={[{ backgroundColor }, style]} {...otherProps} />;
 }

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,10 +1,8 @@
 /**
- * Below are the colors that are used in the app. The colors are defined in the light and dark mode.
- * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
+ * Color palette for the app using only light mode.
  */
 
 const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
 
 export const Colors = {
   light: {
@@ -14,13 +12,5 @@ export const Colors = {
     icon: '#687076',
     tabIconDefault: '#687076',
     tabIconSelected: tintColorLight,
-  },
-  dark: {
-    text: '#ECEDEE',
-    background: '#151718',
-    tint: tintColorDark,
-    icon: '#9BA1A6',
-    tabIconDefault: '#9BA1A6',
-    tabIconSelected: tintColorDark,
   },
 };

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,4 @@
-export { useColorScheme } from 'react-native';
+// Always use light mode throughout the app.
+export function useColorScheme() {
+  return 'light';
+}

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,21 +1,4 @@
-import { useEffect, useState } from 'react';
-import { useColorScheme as useRNColorScheme } from 'react-native';
-
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
+// Web implementation always returns light mode.
 export function useColorScheme() {
-  const [hasHydrated, setHasHydrated] = useState(false);
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
-
-  const colorScheme = useRNColorScheme();
-
-  if (hasHydrated) {
-    return colorScheme;
-  }
-
   return 'light';
 }

--- a/hooks/useThemeColor.ts
+++ b/hooks/useThemeColor.ts
@@ -4,18 +4,17 @@
  */
 
 import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
 
+// Return themed colors using only the light palette.
 export function useThemeColor(
-  props: { light?: string; dark?: string },
-  colorName: keyof typeof Colors.light & keyof typeof Colors.dark
+  props: { light?: string },
+  colorName: keyof typeof Colors.light
 ) {
-  const theme = useColorScheme() ?? 'light';
-  const colorFromProps = props[theme];
+  const colorFromProps = props.light;
 
   if (colorFromProps) {
     return colorFromProps;
   } else {
-    return Colors[theme][colorName];
+    return Colors.light[colorName];
   }
 }


### PR DESCRIPTION
## Summary
- remove dark mode support and force light theme
- add home screen centered in tab bar
- animate AI tutor icon on focus

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot use namespace 'RichEditor' as a type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b157ccbc008329abe21e1a3505d4b8