### PR TITLE
Add dark mode and redesign home screen

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -39,7 +39,7 @@ export default function TabLayout() {
     <Tabs
       initialRouteName="home"
       screenOptions={{
-        tabBarActiveTintColor: Colors.light.tint,
+        tabBarActiveTintColor: Colors.dark.tint,
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,9 +1,74 @@
-import { View, Text, StyleSheet } from 'react-native';
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import AIButton from '@/components/AIButton';
+import { Colors } from '@/constants/Colors';
 
 export default function HomeScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Home</Text>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.header}>
+          <Ionicons
+            name="person-circle-outline"
+            size={40}
+            color={Colors.dark.icon}
+          />
+        </View>
+
+        <View style={styles.card}>
+          <View style={styles.cardText}>
+            <Text style={styles.cardTitle}>Upcoming</Text>
+            <Text style={styles.cardDescription}>
+              Check out the most recent notifications, announcements, test info
+              and more!
+            </Text>
+            <TouchableOpacity style={styles.cardButton}>
+              <Text style={styles.cardButtonText}>Check Out</Text>
+            </TouchableOpacity>
+          </View>
+          <Ionicons
+            name="book-outline"
+            size={72}
+            color={Colors.dark.tint}
+          />
+        </View>
+
+        <View style={styles.dots}>
+          <View style={[styles.dot, styles.activeDot]} />
+          <View style={styles.dot} />
+          <View style={styles.dot} />
+        </View>
+
+        <View style={styles.sectionHeader}>
+          <TouchableOpacity style={styles.dropdown}>
+            <Text style={styles.dropdownText}>Math</Text>
+            <Ionicons
+              name="chevron-down"
+              size={16}
+              color={Colors.dark.text}
+            />
+          </TouchableOpacity>
+          <Text style={styles.sectionSub}>Overview</Text>
+        </View>
+
+        <View style={styles.grid}>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <View key={index} style={styles.tile} />
+          ))}
+        </View>
+      </ScrollView>
+      <AIButton bottomOffset={20} />
     </View>
   );
 }
@@ -11,12 +76,100 @@ export default function HomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: Colors.dark.background,
   },
-  title: {
-    fontSize: 24,
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 100,
+  },
+  header: {
+    alignItems: 'flex-end',
+  },
+  card: {
+    flexDirection: 'row',
+    backgroundColor: Colors.dark.card,
+    padding: 20,
+    borderRadius: 16,
+    alignItems: 'center',
+    marginTop: 20,
+  },
+  cardText: {
+    flex: 1,
+    marginRight: 10,
+  },
+  cardTitle: {
+    color: Colors.dark.text,
+    fontSize: 22,
     fontWeight: 'bold',
+    marginBottom: 6,
+  },
+  cardDescription: {
+    color: Colors.dark.text,
+    fontSize: 14,
+    marginBottom: 12,
+  },
+  cardButton: {
+    backgroundColor: Colors.dark.tint,
+    borderRadius: 20,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    alignSelf: 'flex-start',
+  },
+  cardButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  dots: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 10,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#444',
+    marginHorizontal: 4,
+  },
+  activeDot: {
+    backgroundColor: Colors.dark.tint,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 20,
+    marginBottom: 10,
+  },
+  dropdown: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    backgroundColor: '#1f1f1f',
+    marginRight: 8,
+  },
+  dropdownText: {
+    color: Colors.dark.text,
+    marginRight: 4,
+  },
+  sectionSub: {
+    color: Colors.dark.text,
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  tile: {
+    width: '48%',
+    aspectRatio: 1,
+    backgroundColor: '#1f1f1f',
+    borderRadius: 12,
+    marginBottom: 16,
   },
 });
+

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -15,12 +15,12 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={DefaultTheme}>
+    <ThemeProvider value={DarkTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
-      <StatusBar style="dark" />
+      <StatusBar style="light" />
     </ThemeProvider>
   );
 }

--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -19,7 +19,7 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
           name="chevron.right"
           size={18}
           weight="medium"
-          color={Colors.light.icon}
+          color={Colors.dark.icon}
           style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
         />
 

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -3,17 +3,17 @@ import { StyleSheet, Text, type TextProps } from 'react-native';
 import { useThemeColor } from '@/hooks/useThemeColor';
 
 export type ThemedTextProps = TextProps & {
-  lightColor?: string;
+  darkColor?: string;
   type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
 };
 
 export function ThemedText({
   style,
-  lightColor,
+  darkColor,
   type = 'default',
   ...rest
 }: ThemedTextProps) {
-  const color = useThemeColor({ light: lightColor }, 'text');
+  const color = useThemeColor({ dark: darkColor }, 'text');
 
   return (
     <Text
@@ -53,6 +53,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
+    color: '#9c5dfc',
   },
 });

--- a/components/ThemedView.tsx
+++ b/components/ThemedView.tsx
@@ -3,11 +3,11 @@ import { View, type ViewProps } from 'react-native';
 import { useThemeColor } from '@/hooks/useThemeColor';
 
 export type ThemedViewProps = ViewProps & {
-  lightColor?: string;
+  darkColor?: string;
 };
 
-export function ThemedView({ style, lightColor, ...otherProps }: ThemedViewProps) {
-  const backgroundColor = useThemeColor({ light: lightColor }, 'background');
+export function ThemedView({ style, darkColor, ...otherProps }: ThemedViewProps) {
+  const backgroundColor = useThemeColor({ dark: darkColor }, 'background');
 
   return <View style={[{ backgroundColor }, style]} {...otherProps} />;
 }

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,16 +1,17 @@
 /**
- * Color palette for the app using only light mode.
+ * Color palette for the app using only dark mode.
  */
 
-const tintColorLight = '#0a7ea4';
+const tintColorDark = '#9c5dfc';
 
 export const Colors = {
-  light: {
-    text: '#11181C',
-    background: '#fff',
-    tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
-    tabIconSelected: tintColorLight,
+  dark: {
+    text: '#ffffff',
+    background: '#121212',
+    card: '#1e1e1e',
+    tint: tintColorDark,
+    icon: '#9a9a9a',
+    tabIconDefault: '#9a9a9a',
+    tabIconSelected: tintColorDark,
   },
 };

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,4 +1,4 @@
-// Always use light mode throughout the app.
+// Always use dark mode throughout the app.
 export function useColorScheme() {
-  return 'light';
+  return 'dark';
 }

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,4 +1,4 @@
-// Web implementation always returns light mode.
+// Web implementation always returns dark mode.
 export function useColorScheme() {
-  return 'light';
+  return 'dark';
 }

--- a/hooks/useThemeColor.ts
+++ b/hooks/useThemeColor.ts
@@ -5,16 +5,16 @@
 
 import { Colors } from '@/constants/Colors';
 
-// Return themed colors using only the light palette.
+// Return themed colors using only the dark palette.
 export function useThemeColor(
-  props: { light?: string },
-  colorName: keyof typeof Colors.light
+  props: { dark?: string },
+  colorName: keyof typeof Colors.dark
 ) {
-  const colorFromProps = props.light;
+  const colorFromProps = props.dark;
 
   if (colorFromProps) {
     return colorFromProps;
   } else {
-    return Colors.light[colorName];
+    return Colors.dark[colorName];
   }
 }


### PR DESCRIPTION
## Summary
- switch app to dark theme and remove light mode
- redesign Home tab with upcoming card, subject dropdown, and floating AI button
- update theming utilities and components for dark palette

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15aa853b883298aaca1d3c90f8927