### PR TITLE
Add dark mode notes page and link subject notes from home

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,17 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Modal,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
 
 import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
+import { subjectData, SubjectInfo } from '@/constants/subjects';
 
 export default function HomeScreen() {
+  const [selectedSubject, setSelectedSubject] = useState<SubjectInfo>(subjectData[0]);
+  const [showSubjects, setShowSubjects] = useState(false);
+
   return (
     <View style={styles.container}>
       <ScrollView
@@ -51,8 +57,11 @@ export default function HomeScreen() {
         </View>
 
         <View style={styles.sectionHeader}>
-          <TouchableOpacity style={styles.dropdown}>
-            <Text style={styles.dropdownText}>Math</Text>
+          <TouchableOpacity
+            style={styles.dropdown}
+            onPress={() => setShowSubjects(true)}
+          >
+            <Text style={styles.dropdownText}>{selectedSubject.title}</Text>
             <Ionicons
               name="chevron-down"
               size={16}
@@ -67,8 +76,47 @@ export default function HomeScreen() {
             <View key={index} style={styles.tile} />
           ))}
         </View>
+
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionSub}>Notes</Text>
+        </View>
+        <TouchableOpacity
+          style={styles.notesButton}
+          onPress={() => router.push(`/notes?subject=${selectedSubject.key}`)}
+        >
+          <Text style={styles.notesButtonText}>
+            Go to {selectedSubject.title} Notes
+          </Text>
+        </TouchableOpacity>
       </ScrollView>
       <AIButton bottomOffset={20} />
+      <Modal
+        visible={showSubjects}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowSubjects(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          onPress={() => setShowSubjects(false)}
+          activeOpacity={1}
+        >
+          <View style={styles.modalContent}>
+            {subjectData.map(subject => (
+              <TouchableOpacity
+                key={subject.key}
+                style={styles.modalItem}
+                onPress={() => {
+                  setSelectedSubject(subject);
+                  setShowSubjects(false);
+                }}
+              >
+                <Text style={styles.modalItemText}>{subject.title}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </TouchableOpacity>
+      </Modal>
     </View>
   );
 }
@@ -170,6 +218,36 @@ const styles = StyleSheet.create({
     backgroundColor: '#1f1f1f',
     borderRadius: 12,
     marginBottom: 16,
+  },
+  notesButton: {
+    backgroundColor: Colors.dark.card,
+    padding: 16,
+    borderRadius: 16,
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  notesButtonText: {
+    color: Colors.dark.text,
+    fontWeight: '600',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#1f1f1f',
+    padding: 20,
+    borderRadius: 12,
+    width: '80%',
+  },
+  modalItem: {
+    paddingVertical: 10,
+  },
+  modalItemText: {
+    color: Colors.dark.text,
+    fontSize: 16,
   },
 });
 

--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable import/no-unresolved */
-import React, { useState, useMemo, useRef } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import {
   StyleSheet,
   Text,
@@ -17,7 +16,9 @@ import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { RichEditor, RichToolbar, actions } from 'react-native-pell-rich-editor';
 import RenderHTML from 'react-native-render-html';
+import { useLocalSearchParams } from 'expo-router';
 import AIButton from '../../components/AIButton';
+import { subjectData, SubjectInfo } from '@/constants/subjects';
 
 type Note = {
   id: string;
@@ -28,12 +29,8 @@ type Note = {
   images: string[];
 };
 
-type Subject = {
-  key: string;
-  title: string;
-  icon: keyof typeof Ionicons.glyphMap;
+type Subject = SubjectInfo & {
   notes: Note[];
-  color: string;
 };
 
 const colorOptions = [
@@ -51,15 +48,7 @@ const colorOptions = [
   '#ffeb3b',
 ];
 
-const initialSubjects: Subject[] = [
-  { key: 'english', title: 'English', icon: 'book', notes: [], color: colorOptions[0] },
-  { key: 'arabic', title: 'Arabic', icon: 'globe-outline', notes: [], color: colorOptions[1] },
-  { key: 'math', title: 'Math', icon: 'calculator', notes: [], color: colorOptions[2] },
-  { key: 'physics', title: 'Physics', icon: 'planet', notes: [], color: colorOptions[3] },
-  { key: 'biology', title: 'Biology', icon: 'leaf', notes: [], color: colorOptions[4] },
-  { key: 'business', title: 'Business', icon: 'briefcase', notes: [], color: colorOptions[5] },
-  { key: 'social', title: 'Social Studies', icon: 'people', notes: [], color: colorOptions[6] },
-];
+const initialSubjects: Subject[] = subjectData.map(s => ({ ...s, notes: [] }));
 
 export default function NotesScreen() {
   const [subjects, setSubjects] = useState<Subject[]>(initialSubjects);
@@ -70,10 +59,11 @@ export default function NotesScreen() {
   const [showNoteColors, setShowNoteColors] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const styles = useMemo(() => createStyles(), []);
-  const textColor = '#000';
+  const textColor = '#fff';
   const iconColor = textColor;
   const richText = useRef<RichEditor>(null);
   const { width } = useWindowDimensions();
+  const { subject: subjectParam } = useLocalSearchParams<{ subject?: string }>();
 
   const stripHtml = (html: string) => html.replace(/<[^>]+>/g, '');
   const filteredNotes = useMemo(
@@ -209,16 +199,25 @@ export default function NotesScreen() {
     setActive(prev => (prev && prev.key === active.key ? { ...prev, color } : prev));
   };
 
+  useEffect(() => {
+    if (typeof subjectParam === 'string') {
+      const match = subjects.find(s => s.key === subjectParam);
+      if (match) {
+        setActive(match);
+      }
+    }
+  }, [subjectParam, subjects]);
+
   return (
     <LinearGradient
-      colors={['#cde7ff', '#b7d9ff', '#9ccaff', '#b7d9ff']}
+      colors={['#2e1065', '#000000']}
       style={styles.container}
     >
       <Text style={styles.title}>NOTES</Text>
       <TextInput
         style={styles.searchInput}
         placeholder="Search notes..."
-        placeholderTextColor="#999"
+        placeholderTextColor="#aaa"
         value={searchQuery}
         onChangeText={setSearchQuery}
       />
@@ -351,7 +350,7 @@ export default function NotesScreen() {
               <TextInput
                 style={styles.titleInput}
                 placeholder="Title"
-                placeholderTextColor="#999"
+                placeholderTextColor="#aaa"
                 value={currentNote.title}
                 onChangeText={title => setCurrentNote({ ...currentNote, title })}
               />
@@ -444,13 +443,13 @@ export default function NotesScreen() {
 }
 
 const createStyles = () => {
-  const textColor = '#000';
-  const secondaryText = '#333';
-  const background = '#cde7ff';
-  const toggleBg = '#b7d9ff';
-  const inputBorder = '#99c1ff';
-  const selectedBorder = '#000';
-  const cancelBg = '#b0c4de';
+  const textColor = '#fff';
+  const secondaryText = '#ddd';
+  const background = '#1a1a40';
+  const toggleBg = '#2e1065';
+  const inputBorder = '#444';
+  const selectedBorder = '#fff';
+  const cancelBg = '#333';
   return StyleSheet.create({
     container: {
       flex: 1,

--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -10,11 +10,11 @@ export default function SiriIcon({ size = 60 }: Props) {
   const border = size * 0.03;
   const lineHeight = size * 0.02;
 
-  const containerColor = '#b5d1ff';
-  const notebookBackground = '#333333';
-  const borderColor = '#ffffff';
+  const containerColor = '#cccccc';
+  const notebookBackground = '#eeeeee';
+  const borderColor = '#f5f5f5';
   const lineColor = borderColor;
-  const watermarkColor = '#000000';
+  const watermarkColor = '#bbbbbb';
   const watermarkOutline = '#ffffff';
 
   return (

--- a/constants/subjects.ts
+++ b/constants/subjects.ts
@@ -1,0 +1,19 @@
+import { Ionicons } from '@expo/vector-icons';
+
+export type SubjectInfo = {
+  key: string;
+  title: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+};
+
+export const subjectData: SubjectInfo[] = [
+  { key: 'english', title: 'English', icon: 'book', color: '#3b2e7e' },
+  { key: 'arabic', title: 'Arabic', icon: 'globe-outline', color: '#6a0dad' },
+  { key: 'math', title: 'Math', icon: 'calculator', color: '#1a1a40' },
+  { key: 'physics', title: 'Physics', icon: 'planet', color: '#2e1065' },
+  { key: 'biology', title: 'Biology', icon: 'leaf', color: '#007bff' },
+  { key: 'business', title: 'Business', icon: 'briefcase', color: '#28a745' },
+  { key: 'social', title: 'Social Studies', icon: 'people', color: '#dc3545' },
+];
+


### PR DESCRIPTION
## Summary
- restore dark-themed Notes page with purple-to-black gradient and white text
- add shared subjects list and use it for home dropdown and notes
- gray out AI notebook icon and add notes section on home linking to selected subject

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15e251b908329ae5c0de05b7acdd0