### PR TITLE
Refine home notes placement and AI icon styling

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -71,15 +71,6 @@ export default function HomeScreen() {
           <Text style={styles.sectionSub}>Overview</Text>
         </View>
 
-        <View style={styles.grid}>
-          {Array.from({ length: 8 }).map((_, index) => (
-            <View key={index} style={styles.tile} />
-          ))}
-        </View>
-
-        <View style={styles.sectionHeader}>
-          <Text style={styles.sectionSub}>Notes</Text>
-        </View>
         <TouchableOpacity
           style={styles.notesButton}
           onPress={() => router.push(`/notes?subject=${selectedSubject.key}`)}
@@ -88,6 +79,12 @@ export default function HomeScreen() {
             Go to {selectedSubject.title} Notes
           </Text>
         </TouchableOpacity>
+
+        <View style={styles.grid}>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <View key={index} style={styles.tile} />
+          ))}
+        </View>
       </ScrollView>
       <AIButton bottomOffset={20} />
       <Modal

--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 
 interface Props {
   size?: number;
@@ -10,23 +11,21 @@ export default function SiriIcon({ size = 60 }: Props) {
   const border = size * 0.03;
   const lineHeight = size * 0.02;
 
-  const containerColor = '#cccccc';
-  const notebookBackground = '#eeeeee';
-  const borderColor = '#f5f5f5';
+  const gradientColors = ['#00008b', '#2e1065'];
+  const notebookBackground = '#f5f5f5';
+  const borderColor = '#e0e0e0';
   const lineColor = borderColor;
   const watermarkColor = '#bbbbbb';
   const watermarkOutline = '#ffffff';
 
   return (
-    <View
+    <LinearGradient
+      colors={gradientColors}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
       style={[
         styles.container,
-        {
-          width: size,
-          height: size,
-          borderRadius: size / 2,
-          backgroundColor: containerColor,
-        },
+        { width: size, height: size, borderRadius: size / 2 },
       ]}
     >
       <View
@@ -81,7 +80,7 @@ export default function SiriIcon({ size = 60 }: Props) {
           AI
         </Text>
       </View>
-    </View>
+    </LinearGradient>
   );
 }
 


### PR DESCRIPTION
## Summary
- Use a dark blue to purple gradient behind the AI icon while keeping the notebook grayish white
- Move the "Go to Notes" button directly under the overview on the home screen, removing the separate notes section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b161562c4c8329a80efd2f24bd08e9