### PR TITLE
Add AI loading transition and refine Siri icon

### DIFF
--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -15,7 +15,7 @@ export default function SiriIcon({ size = 60 }: Props) {
   const notebookBackground = '#f5f5f5';
   const borderColor = '#e0e0e0';
   const lineColor = borderColor;
-  const watermarkColor = '#bbbbbb';
+  const watermarkColor = '#000000';
   const watermarkOutline = '#ffffff';
 
   return (
@@ -72,8 +72,8 @@ export default function SiriIcon({ size = 60 }: Props) {
               right: -size * 0.08,
               color: watermarkColor,
               textShadowColor: watermarkOutline,
-              textShadowOffset: { width: 1, height: 1 },
-              textShadowRadius: 1,
+              textShadowOffset: { width: 0, height: 0 },
+              textShadowRadius: size * 0.05,
             },
           ]}
         >


### PR DESCRIPTION
## Summary
- Render Siri icon with black AI text and bold white outline
- Show themed loading overlay with spinning Siri icon before navigating to tutor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b177066c488329ab9e77380a85c50e