### PR TITLE
Fix AI button animation and tutor theme

### DIFF
--- a/app/(tabs)/tutor.tsx
+++ b/app/(tabs)/tutor.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   ScrollView,
 } from 'react-native';
+import { Colors } from '@/constants/Colors';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -87,7 +88,7 @@ export default function TutorScreen() {
           value={input}
           onChangeText={setInput}
           placeholder="Ask about IB Jordan Grade 11..."
-          placeholderTextColor="#888"
+          placeholderTextColor={Colors.dark.icon}
           multiline
         />
         <TouchableOpacity
@@ -105,7 +106,7 @@ export default function TutorScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1c1c1c',
+    backgroundColor: Colors.dark.background,
     padding: 12,
   },
   messages: {
@@ -123,17 +124,17 @@ const styles = StyleSheet.create({
   },
   userMessage: {
     alignSelf: 'flex-end',
-    backgroundColor: '#f4d03f',
+    backgroundColor: Colors.dark.tint,
   },
   assistantMessage: {
     alignSelf: 'flex-start',
-    backgroundColor: '#333',
+    backgroundColor: Colors.dark.card,
   },
   userText: {
-    color: '#1c1c1c',
+    color: Colors.dark.text,
   },
   assistantText: {
-    color: '#f4d03f',
+    color: Colors.dark.text,
   },
   inputRow: {
     flexDirection: 'row',
@@ -141,21 +142,21 @@ const styles = StyleSheet.create({
   },
   input: {
     flex: 1,
-    backgroundColor: '#333',
-    color: '#f4d03f',
+    backgroundColor: Colors.dark.card,
+    color: Colors.dark.text,
     padding: 8,
     borderRadius: 6,
     maxHeight: 120,
   },
   sendButton: {
     marginLeft: 8,
-    backgroundColor: '#f4d03f',
+    backgroundColor: Colors.dark.tint,
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 6,
   },
   sendText: {
-    color: '#1c1c1c',
+    color: Colors.dark.text,
     fontWeight: 'bold',
   },
 });

--- a/components/AIButton.tsx
+++ b/components/AIButton.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export default function AIButton({ bottomOffset = 20, size }: Props) {
   const float = useRef(new Animated.Value(0)).current;
-  const spin = useRef(new Animated.Value(0)).current;
+  const pulse = useRef(new Animated.Value(1)).current;
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -37,29 +37,33 @@ export default function AIButton({ bottomOffset = 20, size }: Props) {
     let animation: Animated.CompositeAnimation | undefined;
     if (loading) {
       animation = Animated.loop(
-        Animated.timing(spin, {
-          toValue: 1,
-          duration: 1000,
-          easing: Easing.linear,
-          useNativeDriver: true,
-        }),
+        Animated.sequence([
+          Animated.timing(pulse, {
+            toValue: 1.2,
+            duration: 500,
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulse, {
+            toValue: 1,
+            duration: 500,
+            useNativeDriver: true,
+          }),
+        ]),
       );
       animation.start();
+    } else {
+      pulse.setValue(1);
     }
     return () => animation?.stop();
-  }, [loading, spin]);
+  }, [loading, pulse]);
 
   const handlePress = () => {
     setLoading(true);
     setTimeout(() => {
+      setLoading(false);
       router.push('/tutor');
     }, 1000);
   };
-
-  const rotate = spin.interpolate({
-    inputRange: [0, 1],
-    outputRange: ['0deg', '360deg'],
-  });
 
   return (
     <>
@@ -75,7 +79,7 @@ export default function AIButton({ bottomOffset = 20, size }: Props) {
       </Animated.View>
       {loading && (
         <LinearGradient colors={['#00008b', '#2e1065']} style={styles.overlay}>
-          <Animated.View style={{ transform: [{ rotate }] }}>
+          <Animated.View style={{ transform: [{ scale: pulse }] }}>
             <SiriIcon size={(size ?? 60) * 1.5} />
           </Animated.View>
         </LinearGradient>


### PR DESCRIPTION
## Summary
- replace rotating loader with pulsing zoom for AI button
- stop loading overlay after navigation
- restyle Tutor screen using shared dark theme colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b182ebb4f083298853bbc5b1d01159