### PR TITLE
feat: add settings and light mode

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -6,6 +6,7 @@ import {
   ScrollView,
   TouchableOpacity,
   Modal,
+  Switch,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
@@ -14,9 +15,35 @@ import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
 import { subjectData, SubjectInfo } from '@/constants/subjects';
 
+const cardData = [
+  {
+    title: 'Upcoming',
+    description:
+      'Check out the most recent notifications, announcements, test info and more!',
+    icon: 'book-outline' as const,
+  },
+  {
+    title: 'Result logging',
+    description: 'Log and review your results.',
+    icon: 'clipboard-outline' as const,
+  },
+  {
+    title: 'AI feedback',
+    description: 'Get insights and feedback from the AI.',
+    icon: 'chatbubbles-outline' as const,
+  },
+];
+
 export default function HomeScreen() {
   const [selectedSubject, setSelectedSubject] = useState<SubjectInfo>(subjectData[0]);
   const [showSubjects, setShowSubjects] = useState(false);
+  const [settingsVisible, setSettingsVisible] = useState(false);
+  const [isLightMode, setIsLightMode] = useState(false);
+  const [activeCard, setActiveCard] = useState(0);
+
+  const theme = isLightMode ? Colors.light : Colors.dark;
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const currentCard = cardData[activeCard];
 
   return (
     <View style={styles.container}>
@@ -25,35 +52,31 @@ export default function HomeScreen() {
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.header}>
-          <Ionicons
-            name="person-circle-outline"
-            size={40}
-            color={Colors.dark.icon}
-          />
+          <TouchableOpacity onPress={() => setSettingsVisible(true)}>
+            <Ionicons name="settings-outline" size={28} color={theme.icon} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Clarity</Text>
         </View>
 
         <View style={styles.card}>
           <View style={styles.cardText}>
-            <Text style={styles.cardTitle}>Upcoming</Text>
-            <Text style={styles.cardDescription}>
-              Check out the most recent notifications, announcements, test info
-              and more!
-            </Text>
+            <Text style={styles.cardTitle}>{currentCard.title}</Text>
+            <Text style={styles.cardDescription}>{currentCard.description}</Text>
             <TouchableOpacity style={styles.cardButton}>
               <Text style={styles.cardButtonText}>Check Out</Text>
             </TouchableOpacity>
           </View>
-          <Ionicons
-            name="book-outline"
-            size={72}
-            color={Colors.dark.tint}
-          />
+          <Ionicons name={currentCard.icon} size={72} color={theme.tint} />
         </View>
 
         <View style={styles.dots}>
-          <View style={[styles.dot, styles.activeDot]} />
-          <View style={styles.dot} />
-          <View style={styles.dot} />
+          {cardData.map((_, index) => (
+            <TouchableOpacity
+              key={index}
+              style={[styles.dot, index === activeCard && styles.activeDot]}
+              onPress={() => setActiveCard(index)}
+            />
+          ))}
         </View>
 
         <View style={styles.sectionHeader}>
@@ -62,11 +85,7 @@ export default function HomeScreen() {
             onPress={() => setShowSubjects(true)}
           >
             <Text style={styles.dropdownText}>{selectedSubject.title}</Text>
-            <Ionicons
-              name="chevron-down"
-              size={16}
-              color={Colors.dark.text}
-            />
+            <Ionicons name="chevron-down" size={16} color={theme.text} />
           </TouchableOpacity>
           <Text style={styles.sectionSub}>Overview</Text>
         </View>
@@ -87,6 +106,33 @@ export default function HomeScreen() {
         </View>
       </ScrollView>
       <AIButton bottomOffset={20} />
+
+      {/* Settings Modal */}
+      <Modal
+        visible={settingsVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSettingsVisible(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          onPress={() => setSettingsVisible(false)}
+          activeOpacity={1}
+        >
+          <View style={styles.settingsContent}>
+            <Text style={styles.settingsTitle}>Settings</Text>
+            <View style={styles.settingRow}>
+              <Text style={styles.settingText}>Light Mode</Text>
+              <Switch value={isLightMode} onValueChange={setIsLightMode} />
+            </View>
+            <Text style={styles.settingPlaceholder}>
+              More customization options coming soon...
+            </Text>
+          </View>
+        </TouchableOpacity>
+      </Modal>
+
+      {/* Subject Selection Modal */}
       <Modal
         visible={showSubjects}
         transparent
@@ -118,133 +164,167 @@ export default function HomeScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.dark.background,
-  },
-  content: {
-    paddingHorizontal: 20,
-    paddingTop: 20,
-    paddingBottom: 100,
-  },
-  header: {
-    alignItems: 'flex-end',
-  },
-  card: {
-    flexDirection: 'row',
-    backgroundColor: Colors.dark.card,
-    padding: 20,
-    borderRadius: 16,
-    alignItems: 'center',
-    marginTop: 20,
-  },
-  cardText: {
-    flex: 1,
-    marginRight: 10,
-  },
-  cardTitle: {
-    color: Colors.dark.text,
-    fontSize: 22,
-    fontWeight: 'bold',
-    marginBottom: 6,
-  },
-  cardDescription: {
-    color: Colors.dark.text,
-    fontSize: 14,
-    marginBottom: 12,
-  },
-  cardButton: {
-    backgroundColor: Colors.dark.tint,
-    borderRadius: 20,
-    paddingVertical: 6,
-    paddingHorizontal: 16,
-    alignSelf: 'flex-start',
-  },
-  cardButtonText: {
-    color: '#fff',
-    fontWeight: '600',
-  },
-  dots: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    marginTop: 10,
-  },
-  dot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: '#444',
-    marginHorizontal: 4,
-  },
-  activeDot: {
-    backgroundColor: Colors.dark.tint,
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: 20,
-    marginBottom: 10,
-  },
-  dropdown: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 4,
-    paddingHorizontal: 10,
-    borderRadius: 8,
-    backgroundColor: '#1f1f1f',
-    marginRight: 8,
-  },
-  dropdownText: {
-    color: Colors.dark.text,
-    marginRight: 4,
-  },
-  sectionSub: {
-    color: Colors.dark.text,
-    fontWeight: '600',
-    fontSize: 16,
-  },
-  grid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-  },
-  tile: {
-    width: '48%',
-    aspectRatio: 1,
-    backgroundColor: '#1f1f1f',
-    borderRadius: 12,
-    marginBottom: 16,
-  },
-  notesButton: {
-    backgroundColor: Colors.dark.card,
-    padding: 16,
-    borderRadius: 16,
-    alignItems: 'center',
-    marginBottom: 20,
-  },
-  notesButtonText: {
-    color: Colors.dark.text,
-    fontWeight: '600',
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  modalContent: {
-    backgroundColor: '#1f1f1f',
-    padding: 20,
-    borderRadius: 12,
-    width: '80%',
-  },
-  modalItem: {
-    paddingVertical: 10,
-  },
-  modalItemText: {
-    color: Colors.dark.text,
-    fontSize: 16,
-  },
-});
+const createStyles = (colors: typeof Colors.dark) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    content: {
+      paddingHorizontal: 20,
+      paddingTop: 60,
+      paddingBottom: 100,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    headerTitle: {
+      color: colors.text,
+      fontSize: 22,
+      fontWeight: 'bold',
+      marginLeft: 8,
+    },
+    card: {
+      flexDirection: 'row',
+      backgroundColor: colors.card,
+      padding: 20,
+      borderRadius: 16,
+      alignItems: 'center',
+      marginTop: 20,
+    },
+    cardText: {
+      flex: 1,
+      marginRight: 10,
+    },
+    cardTitle: {
+      color: colors.text,
+      fontSize: 22,
+      fontWeight: 'bold',
+      marginBottom: 6,
+    },
+    cardDescription: {
+      color: colors.text,
+      fontSize: 14,
+      marginBottom: 12,
+    },
+    cardButton: {
+      backgroundColor: colors.tint,
+      borderRadius: 20,
+      paddingVertical: 6,
+      paddingHorizontal: 16,
+      alignSelf: 'flex-start',
+    },
+    cardButtonText: {
+      color: '#fff',
+      fontWeight: '600',
+    },
+    dots: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      marginTop: 10,
+    },
+    dot: {
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      backgroundColor: '#444',
+      marginHorizontal: 4,
+    },
+    activeDot: {
+      backgroundColor: colors.tint,
+    },
+    sectionHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: 20,
+      marginBottom: 10,
+    },
+    dropdown: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 4,
+      paddingHorizontal: 10,
+      borderRadius: 8,
+      backgroundColor: '#1f1f1f',
+      marginRight: 8,
+    },
+    dropdownText: {
+      color: colors.text,
+      marginRight: 4,
+    },
+    sectionSub: {
+      color: colors.text,
+      fontWeight: '600',
+      fontSize: 16,
+    },
+    grid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+    },
+    tile: {
+      width: '48%',
+      aspectRatio: 1,
+      backgroundColor: '#1f1f1f',
+      borderRadius: 12,
+      marginBottom: 16,
+    },
+    notesButton: {
+      backgroundColor: colors.card,
+      padding: 16,
+      borderRadius: 16,
+      alignItems: 'center',
+      marginBottom: 20,
+    },
+    notesButtonText: {
+      color: colors.text,
+      fontWeight: '600',
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalContent: {
+      backgroundColor: '#1f1f1f',
+      padding: 20,
+      borderRadius: 12,
+      width: '80%',
+    },
+    modalItem: {
+      paddingVertical: 10,
+    },
+    modalItemText: {
+      color: colors.text,
+      fontSize: 16,
+    },
+    settingsContent: {
+      backgroundColor: colors.card,
+      padding: 20,
+      borderRadius: 12,
+      width: '80%',
+    },
+    settingsTitle: {
+      color: colors.text,
+      fontSize: 18,
+      fontWeight: '600',
+      marginBottom: 12,
+    },
+    settingRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 16,
+    },
+    settingText: {
+      color: colors.text,
+      fontSize: 16,
+    },
+    settingPlaceholder: {
+      color: colors.text,
+      fontSize: 14,
+    },
+  });
 

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,17 +1,26 @@
 /**
- * Color palette for the app using only dark mode.
+ * Color palette for the app supporting light and dark modes.
  */
 
-const tintColorDark = '#9c5dfc';
+const tintColor = '#9c5dfc';
 
 export const Colors = {
+  light: {
+    text: '#000000',
+    background: '#ffffff',
+    card: '#f2f2f2',
+    tint: tintColor,
+    icon: '#555555',
+    tabIconDefault: '#555555',
+    tabIconSelected: tintColor,
+  },
   dark: {
     text: '#ffffff',
     background: '#121212',
     card: '#1e1e1e',
-    tint: tintColorDark,
+    tint: tintColor,
     icon: '#9a9a9a',
     tabIconDefault: '#9a9a9a',
-    tabIconSelected: tintColorDark,
+    tabIconSelected: tintColor,
   },
-};
+} as const;


### PR DESCRIPTION
## Summary
- add configurable light mode with settings menu
- show Clarity header with settings access on home screen
- convert Upcoming card into three-tab carousel: Upcoming, Result logging, AI feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b184fff0e08329a7302413d0cd0931