### PR TITLE
Improve AI button visibility and placement

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -434,7 +434,7 @@ export default function NotesScreen() {
                 </TouchableOpacity>
               </View>
             </ScrollView>
-            <AIButton bottomOffset={100} />
+            <AIButton bottomOffset={20} size={40} align="right" />
           </View>
         )}
       </Modal>

--- a/components/AIButton.tsx
+++ b/components/AIButton.tsx
@@ -7,9 +7,16 @@ import SiriIcon from './SiriIcon';
 interface Props {
   bottomOffset?: number;
   size?: number;
+  align?: 'center' | 'right';
+  rightOffset?: number;
 }
 
-export default function AIButton({ bottomOffset = 20, size }: Props) {
+export default function AIButton({
+  bottomOffset = 20,
+  size,
+  align = 'center',
+  rightOffset = 20,
+}: Props) {
   const float = useRef(new Animated.Value(0)).current;
   const pulse = useRef(new Animated.Value(1)).current;
   const [loading, setLoading] = useState(false);
@@ -71,6 +78,9 @@ export default function AIButton({ bottomOffset = 20, size }: Props) {
         style={[
           styles.container,
           { transform: [{ translateY: float }], bottom: bottomOffset },
+          align === 'right'
+            ? { right: rightOffset, alignSelf: 'flex-end' }
+            : { alignSelf: 'center' },
         ]}
       >
         <TouchableOpacity onPress={handlePress}>
@@ -91,7 +101,6 @@ export default function AIButton({ bottomOffset = 20, size }: Props) {
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    alignSelf: 'center',
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,

--- a/components/SiriIcon.tsx
+++ b/components/SiriIcon.tsx
@@ -73,7 +73,7 @@ export default function SiriIcon({ size = 60 }: Props) {
               color: watermarkColor,
               textShadowColor: watermarkOutline,
               textShadowOffset: { width: 0, height: 0 },
-              textShadowRadius: size * 0.05,
+              textShadowRadius: size * 0.15,
             },
           ]}
         >


### PR DESCRIPTION
## Summary
- increase AI icon watermark outline for better readability
- allow AI button to align to right and use it bottom-right in note editor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3491d67ac8329abf08f89ce1e2f71