### PR TITLE
feat: add subject creation and schedule events

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -58,6 +58,9 @@ export default function NotesScreen() {
   const [showSubjectColors, setShowSubjectColors] = useState(false);
   const [showNoteColors, setShowNoteColors] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [addSubjectModalVisible, setAddSubjectModalVisible] = useState(false);
+  const [newSubjectTitle, setNewSubjectTitle] = useState('');
+  const [newSubjectColor, setNewSubjectColor] = useState(colorOptions[0]);
   const styles = useMemo(() => createStyles(), []);
   const textColor = '#fff';
   const iconColor = textColor;
@@ -199,6 +202,23 @@ export default function NotesScreen() {
     setActive(prev => (prev && prev.key === active.key ? { ...prev, color } : prev));
   };
 
+  const handleAddSubject = () => {
+    if (!newSubjectTitle.trim()) return;
+    const key =
+      newSubjectTitle.toLowerCase().replace(/\s+/g, '-') + '-' + Date.now().toString();
+    const newSubject: Subject = {
+      key,
+      title: newSubjectTitle.trim(),
+      icon: 'book',
+      color: newSubjectColor,
+      notes: [],
+    };
+    setSubjects(prev => [...prev, newSubject]);
+    setAddSubjectModalVisible(false);
+    setNewSubjectTitle('');
+    setNewSubjectColor(colorOptions[0]);
+  };
+
   useEffect(() => {
     if (typeof subjectParam === 'string') {
       const match = subjects.find(s => s.key === subjectParam);
@@ -260,9 +280,54 @@ export default function NotesScreen() {
               )}
             </TouchableOpacity>
           ))}
+          <TouchableOpacity
+            key="add-subject"
+            style={[styles.box, styles.addBox]}
+            onPress={() => setAddSubjectModalVisible(true)}
+          >
+            <Ionicons name="add" size={32} color={iconColor} />
+            <Text style={styles.boxTitle}>ADD</Text>
+          </TouchableOpacity>
         </ScrollView>
       )}
       <AIButton />
+
+      <Modal visible={addSubjectModalVisible} animationType="slide">
+        <View style={styles.addSubjectContainer}>
+          <Text style={styles.modalTitle}>Add Subject</Text>
+          <TextInput
+            style={styles.titleInput}
+            placeholder="Subject Name"
+            placeholderTextColor="#aaa"
+            value={newSubjectTitle}
+            onChangeText={setNewSubjectTitle}
+          />
+          <View style={styles.colorRow}>
+            {colorOptions.map(c => (
+              <TouchableOpacity
+                key={c}
+                style={[
+                  styles.colorSwatch,
+                  { backgroundColor: c },
+                  newSubjectColor === c && styles.selectedSwatch,
+                ]}
+                onPress={() => setNewSubjectColor(c)}
+              />
+            ))}
+          </View>
+          <View style={styles.noteModalButtons}>
+            <TouchableOpacity style={styles.saveButton} onPress={handleAddSubject}>
+              <Text style={styles.saveButtonText}>Save</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.cancelButton}
+              onPress={() => setAddSubjectModalVisible(false)}
+            >
+              <Text style={styles.saveButtonText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
 
       <Modal visible={!!active} animationType="slide">
         {active && (
@@ -486,6 +551,12 @@ const createStyles = () => {
       marginBottom: 12,
       alignItems: 'center',
     },
+    addBox: {
+      borderWidth: 1,
+      borderColor: inputBorder,
+      backgroundColor: 'transparent',
+      justifyContent: 'center',
+    },
     boxTitle: {
       marginTop: 8,
       color: textColor,
@@ -588,6 +659,12 @@ const createStyles = () => {
       flex: 1,
       backgroundColor: background,
       paddingTop: 32,
+    },
+    addSubjectContainer: {
+      flex: 1,
+      backgroundColor: background,
+      paddingTop: 32,
+      padding: 16,
     },
     titleInput: {
       borderColor: inputBorder,

--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -1,22 +1,200 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  TouchableOpacity,
+  Modal,
+  TextInput,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { LinearGradient } from 'expo-linear-gradient';
+
+type Event = {
+  id: string;
+  title: string;
+  date: Date;
+};
 
 export default function ScheduleScreen() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newDate, setNewDate] = useState(new Date());
+  const [showPicker, setShowPicker] = useState(false);
+
+  const addEvent = () => {
+    setEvents(prev => [
+      ...prev,
+      { id: Date.now().toString(), title: newTitle || 'Untitled', date: newDate },
+    ]);
+    setModalVisible(false);
+    setNewTitle('');
+    setNewDate(new Date());
+  };
+
+  const onChange = (_: any, selectedDate?: Date) => {
+    setShowPicker(false);
+    if (selectedDate) setNewDate(selectedDate);
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>📅 Schedule Screen</Text>
-    </View>
+    <LinearGradient colors={['#2e1065', '#000']} style={styles.container}>
+      <Text style={styles.title}>SCHEDULE</Text>
+      <ScrollView contentContainerStyle={styles.content}>
+        {events.map(event => (
+          <View key={event.id} style={styles.eventCard}>
+            <Text style={styles.eventTitle}>{event.title}</Text>
+            <Text style={styles.eventDate}>{event.date.toLocaleString()}</Text>
+          </View>
+        ))}
+        {events.length === 0 && (
+          <Text style={styles.emptyText}>No events yet.</Text>
+        )}
+      </ScrollView>
+      <TouchableOpacity
+        style={styles.addButton}
+        onPress={() => setModalVisible(true)}
+      >
+        <Ionicons name="add" size={28} color="#fff" />
+      </TouchableOpacity>
+
+      <Modal visible={modalVisible} animationType="slide">
+        <View style={styles.modalContainer}>
+          <Text style={styles.modalTitle}>Add Event</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Event title"
+            placeholderTextColor="#aaa"
+            value={newTitle}
+            onChangeText={setNewTitle}
+          />
+          <TouchableOpacity
+            style={styles.dateButton}
+            onPress={() => setShowPicker(true)}
+          >
+            <Ionicons name="calendar" size={20} color="#fff" />
+            <Text style={styles.dateButtonText}>
+              {newDate.toLocaleString()}
+            </Text>
+          </TouchableOpacity>
+          {showPicker && (
+            <DateTimePicker
+              value={newDate}
+              mode="datetime"
+              display="default"
+              onChange={onChange}
+            />
+          )}
+          <View style={styles.modalButtons}>
+            <TouchableOpacity style={styles.saveButton} onPress={addEvent}>
+              <Text style={styles.saveButtonText}>Save</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.cancelButton}
+              onPress={() => setModalVisible(false)}
+            >
+              <Text style={styles.saveButtonText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#1c1c1c',
-    alignItems: 'center',
-    justifyContent: 'center',
+  container: { flex: 1 },
+  title: {
+    color: '#fff',
+    fontSize: 24,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginTop: 40,
+    marginBottom: 16,
   },
-  text: {
-    fontSize: 22,
-    color: '#f4d03f',
+  content: {
+    padding: 16,
+    paddingBottom: 100,
+  },
+  eventCard: {
+    backgroundColor: '#2e1065',
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  eventTitle: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  eventDate: {
+    color: '#ddd',
+    marginTop: 4,
+  },
+  emptyText: {
+    color: '#fff',
+    textAlign: 'center',
+    marginTop: 32,
+  },
+  addButton: {
+    position: 'absolute',
+    right: 20,
+    bottom: 40,
+    backgroundColor: '#2e1065',
+    borderRadius: 30,
+    padding: 16,
+  },
+  modalContainer: {
+    flex: 1,
+    backgroundColor: '#1a1a40',
+    paddingTop: 60,
+    padding: 16,
+  },
+  modalTitle: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  input: {
+    borderColor: '#444',
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    color: '#fff',
+    marginBottom: 16,
+  },
+  dateButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#2e1065',
+    padding: 12,
+    borderRadius: 8,
+  },
+  dateButtonText: {
+    color: '#fff',
+    marginLeft: 8,
+  },
+  modalButtons: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginTop: 24,
+  },
+  saveButton: {
+    backgroundColor: '#2e1065',
+    padding: 16,
+    borderRadius: 8,
+  },
+  cancelButton: {
+    backgroundColor: '#333',
+    padding: 16,
+    borderRadius: 8,
+  },
+  saveButtonText: {
+    color: '#fff',
   },
 });
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-community/datetimepicker": "^8.4.4",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2801,6 +2802,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
+      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-community/datetimepicker": "^8.4.4",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",


### PR DESCRIPTION
## Summary
- allow users to add custom subjects in Notes via plus card and modal
- implement schedule screen with event list, date picker and add-event modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b351b851b08329a304489c923df37c