### PR TITLE
Add open library search and study planner tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -96,6 +96,24 @@ export default function TabLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="library"
+        options={{
+          title: 'Library',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons size={28} name="local-library" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="planner"
+        options={{
+          title: 'Planner',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons size={28} name="event-note" color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
+import { Colors } from '@/constants/Colors';
+
+interface Book {
+  key: string;
+  title: string;
+  author_name?: string[];
+  first_publish_year?: number;
+}
+
+export default function LibraryScreen() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Book[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const search = async () => {
+    if (!query.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=20`
+      );
+      const data = await res.json();
+      setResults(data.docs || []);
+    } catch {
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.searchRow}>
+        <TextInput
+          style={styles.input}
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search Open Library..."
+          placeholderTextColor={Colors.dark.icon}
+        />
+        <TouchableOpacity style={styles.button} onPress={search}>
+          <Text style={styles.buttonText}>Go</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.results} contentContainerStyle={styles.resultsContent}>
+        {loading && <Text style={styles.loading}>Loading...</Text>}
+        {results.map(book => (
+          <View key={book.key} style={styles.card}>
+            <Text style={styles.title}>{book.title}</Text>
+            {book.author_name && (
+              <Text style={styles.author}>{book.author_name.join(', ')}</Text>
+            )}
+            {book.first_publish_year && (
+              <Text style={styles.year}>{book.first_publish_year}</Text>
+            )}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.dark.background,
+    padding: 16,
+  },
+  searchRow: {
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: Colors.dark.card,
+    color: Colors.dark.text,
+    padding: 8,
+    borderRadius: 6,
+  },
+  button: {
+    marginLeft: 8,
+    backgroundColor: Colors.dark.tint,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+    borderRadius: 6,
+  },
+  buttonText: {
+    color: Colors.dark.text,
+    fontWeight: 'bold',
+  },
+  results: {
+    flex: 1,
+  },
+  resultsContent: {
+    paddingBottom: 40,
+  },
+  card: {
+    backgroundColor: Colors.dark.card,
+    padding: 12,
+    borderRadius: 6,
+    marginBottom: 10,
+  },
+  title: {
+    color: Colors.dark.text,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  author: {
+    color: Colors.dark.text,
+    marginTop: 4,
+  },
+  year: {
+    color: Colors.dark.icon,
+    marginTop: 2,
+  },
+  loading: {
+    color: Colors.dark.text,
+    textAlign: 'center',
+    marginVertical: 20,
+  },
+});
+

--- a/app/(tabs)/planner.tsx
+++ b/app/(tabs)/planner.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
+import { Colors } from '@/constants/Colors';
+import { subjectData } from '@/constants/subjects';
+
+export default function PlannerScreen() {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [plan, setPlan] = useState<{ day: string; subject: string }[]>([]);
+
+  const toggleSubject = (key: string) => {
+    setSelected(prev =>
+      prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]
+    );
+  };
+
+  const generatePlan = () => {
+    const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+    const chosen = subjectData.filter(s => selected.includes(s.key));
+    const sessions: { day: string; subject: string }[] = [];
+    let dayIndex = 0;
+    chosen.forEach(sub => {
+      sessions.push({ day: days[dayIndex % days.length], subject: sub.title });
+      dayIndex++;
+    });
+    setPlan(sessions);
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.header}>Select your subjects</Text>
+      <View style={styles.subjects}>
+        {subjectData.map(subject => {
+          const active = selected.includes(subject.key);
+          return (
+            <TouchableOpacity
+              key={subject.key}
+              style={[styles.subjectItem, active && styles.subjectItemActive]}
+              onPress={() => toggleSubject(subject.key)}
+            >
+              <Text style={styles.subjectText}>{subject.title}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+      <TouchableOpacity style={styles.generateButton} onPress={generatePlan}>
+        <Text style={styles.generateText}>Generate Study Plan</Text>
+      </TouchableOpacity>
+      {plan.length > 0 && (
+        <View style={styles.plan}>
+          {plan.map((p, idx) => (
+            <Text key={idx} style={styles.planText}>
+              {p.day}: {p.subject}
+            </Text>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.dark.background,
+  },
+  content: {
+    padding: 16,
+  },
+  header: {
+    color: Colors.dark.text,
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  subjects: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 16,
+  },
+  subjectItem: {
+    backgroundColor: Colors.dark.card,
+    padding: 8,
+    borderRadius: 6,
+    margin: 4,
+  },
+  subjectItemActive: {
+    backgroundColor: Colors.dark.tint,
+  },
+  subjectText: {
+    color: Colors.dark.text,
+  },
+  generateButton: {
+    backgroundColor: Colors.dark.tint,
+    padding: 12,
+    borderRadius: 6,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  generateText: {
+    color: Colors.dark.text,
+    fontWeight: 'bold',
+  },
+  plan: {
+    backgroundColor: Colors.dark.card,
+    padding: 12,
+    borderRadius: 6,
+  },
+  planText: {
+    color: Colors.dark.text,
+    marginBottom: 4,
+  },
+});
+


### PR DESCRIPTION
## Summary
- add Library tab that queries Open Library API for books
- add Planner tab to generate simple weekly study schedule
- update tab layout to include new Library and Planner screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3663000c88329ae14b5af75a9b41b