### PR TITLE
Add Scholar section mini-tabs

### DIFF
--- a/app/(tabs)/scholar/_layout.tsx
+++ b/app/(tabs)/scholar/_layout.tsx
@@ -1,0 +1,22 @@
+import { withLayoutContext } from 'expo-router';
+import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import { Colors } from '@/constants/Colors';
+
+const { Navigator } = createMaterialTopTabNavigator();
+const TopTabs = withLayoutContext(Navigator);
+
+export default function ScholarLayout() {
+  return (
+    <TopTabs
+      screenOptions={{
+        tabBarActiveTintColor: Colors.dark.tint,
+        tabBarIndicatorStyle: { backgroundColor: Colors.dark.tint },
+        tabBarStyle: { backgroundColor: Colors.dark.background },
+      }}
+    >
+      <TopTabs.Screen name="curriculum" options={{ title: 'Curriculum' }} />
+      <TopTabs.Screen name="library" options={{ title: 'Library' }} />
+      <TopTabs.Screen name="planner" options={{ title: 'AI Planner' }} />
+    </TopTabs>
+  );
+}

--- a/app/(tabs)/scholar/curriculum.tsx
+++ b/app/(tabs)/scholar/curriculum.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Colors } from '@/constants/Colors';
+
+export default function CurriculumScreen() {
+  return (
+    <LinearGradient colors={['#6a0dad', '#0000ff']} style={styles.container}>
+      <View style={styles.center}>
+        <Text style={styles.text}>Curriculum content coming soon.</Text>
+      </View>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { color: Colors.dark.text, fontSize: 18 },
+});

--- a/app/(tabs)/scholar/library.tsx
+++ b/app/(tabs)/scholar/library.tsx
@@ -3,11 +3,11 @@ import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Colors } from '@/constants/Colors';
 
-export default function ScholarScreen() {
+export default function LibraryScreen() {
   return (
     <LinearGradient colors={['#6a0dad', '#0000ff']} style={styles.container}>
       <View style={styles.center}>
-        <Text style={styles.text}>Scholar resources coming soon.</Text>
+        <Text style={styles.text}>Library resources coming soon.</Text>
       </View>
     </LinearGradient>
   );

--- a/app/(tabs)/scholar/planner.tsx
+++ b/app/(tabs)/scholar/planner.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Colors } from '@/constants/Colors';
+
+export default function PlannerScreen() {
+  return (
+    <LinearGradient colors={['#6a0dad', '#0000ff']} style={styles.container}>
+      <View style={styles.center}>
+        <Text style={styles.text}>AI Planner coming soon.</Text>
+      </View>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { color: Colors.dark.text, fontSize: 18 },
+});


### PR DESCRIPTION
## Summary
- add top-level mini-tabs to Scholar screen for Curriculum, Library, and AI Planner
- scaffold placeholder screens for each mini-tab

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3786f558483299513a23401ddee7f