### PR TITLE
Adjust tab bar for safe area insets

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Tabs } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import React from 'react';
 import { Platform, Animated } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
@@ -35,6 +36,8 @@ function TutorIcon({ color, focused }: { color: string; focused: boolean }) {
 }
 
 export default function TabLayout() {
+  const insets = useSafeAreaInsets();
+
   return (
     <Tabs
       initialRouteName="home"
@@ -43,13 +46,17 @@ export default function TabLayout() {
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
-        tabBarStyle: Platform.select({
-          ios: {
-            // Use a transparent background on iOS to show the blur effect
-            position: 'absolute',
-          },
-          default: {},
-        }),
+        tabBarStyle: {
+          ...Platform.select({
+            ios: {
+              // Use a transparent background on iOS to show the blur effect
+              position: 'absolute',
+            },
+            default: {},
+          }),
+          height: 60 + insets.bottom,
+          paddingBottom: insets.bottom,
+        },
       }}>
       <Tabs.Screen
         name="notes"


### PR DESCRIPTION
## Summary
- use safe area insets to add bottom padding and height to the tab bar

## Testing
- `npm run lint` *(fails: Unable to resolve path to module '@react-navigation/material-top-tabs')*

------
https://chatgpt.com/codex/tasks/task_e_68b37c63019c832994beaa39957b979c