### PR TITLE
feat(auth): open Google login in secure browser

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,8 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={DarkTheme}>
-      <Stack>
+      <Stack initialRouteName="login">
+        <Stack.Screen name="login" options={{ title: 'Login' }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import * as Linking from 'expo-linking';
+
+WebBrowser.maybeCompleteAuthSession();
+
+export default function LoginScreen() {
+  const handleLogin = async () => {
+    const redirectUri = Linking.createURL('/auth-callback');
+    const authUrl =
+      'https://accounts.google.com/o/oauth2/v2/auth?response_type=code' +
+      `&client_id=${encodeURIComponent(process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ?? '')}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      '&scope=openid%20email%20profile';
+    const result = await WebBrowser.openAuthSessionAsync(authUrl, redirectUri);
+    if (result.type === 'success' && result.url) {
+      const code = new URL(result.url).searchParams.get('code');
+      if (code) {
+        // TODO: Send code to backend and exchange for tokens
+      }
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Sign in with Google" onPress={handleLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+});

--- a/server.mjs
+++ b/server.mjs
@@ -3,13 +3,15 @@ import fetch from 'node-fetch';
 import crypto from 'node:crypto';
 
 const app = express();
+app.use(express.urlencoded({ extended: true }));
 
 // Your Google client ID/secret
 const CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 
 // The redirect URI MUST exactly match one configured in Google Cloud Console
-const REDIRECT_URI = 'https://auth.openai.com/api/accounts/callback/google';
+// This should point back to the Expo app using a custom scheme.
+const REDIRECT_URI = 'myibapp://auth-callback';
 
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
@@ -32,14 +34,14 @@ app.get('/auth/google', (req, res) => {
   res.redirect(url.toString());
 });
 
-// Step 2: handle the callback and exchange code for tokens
-app.get('/api/accounts/callback/google', async (req, res) => {
-  const { code } = req.query;
+// Step 2: exchange authorization code for tokens
+app.post('/auth/google/token', async (req, res) => {
+  const { code } = req.body;
   const resp = await fetch(GOOGLE_TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
-      code: code,
+      code,
       client_id: CLIENT_ID,
       client_secret: CLIENT_SECRET,
       redirect_uri: REDIRECT_URI,


### PR DESCRIPTION
## Summary
- add login screen that opens Google OAuth in a system browser
- make login the initial route in the app stack
- update Express server to redirect to a custom scheme and expose a token exchange endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b410f6c7a08329bc79746652d2003f