### PR TITLE
Add Google OAuth configuration and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+EXPO_PUBLIC_GOOGLE_CLIENT_ID=your_client_id
+GOOGLE_CLIENT_ID=your_client_id
+GOOGLE_CLIENT_SECRET=your_client_secret

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The Tutor tab connects to a ChatGPT-powered assistant focused on the IB system i
 EXPO_PUBLIC_OPENAI_API_KEY=your_key_here npx expo start
 ```
 
+## Google Sign-In
+
+Google authentication requires OAuth credentials. Provide the client ID when starting the Expo app and both the client ID and secret when running the Express backend:
+
+```bash
+EXPO_PUBLIC_GOOGLE_CLIENT_ID=your_client_id npx expo start
+
+GOOGLE_CLIENT_ID=your_client_id GOOGLE_CLIENT_SECRET=your_client_secret node server.mjs
+```
+
+For convenience, copy `.env.example` to `.env` and fill in your own values.
+
 ## Join the community
 
 Join our community of developers creating universal apps.

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { View, Button, StyleSheet, Alert } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
 
@@ -7,10 +7,19 @@ WebBrowser.maybeCompleteAuthSession();
 
 export default function LoginScreen() {
   const handleLogin = async () => {
+    const clientId = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID;
+    if (!clientId) {
+      Alert.alert(
+        'Missing configuration',
+        'EXPO_PUBLIC_GOOGLE_CLIENT_ID is not set. Please configure your Google OAuth client ID.'
+      );
+      return;
+    }
+
     const redirectUri = Linking.createURL('/auth-callback');
     const authUrl =
       'https://accounts.google.com/o/oauth2/v2/auth?response_type=code' +
-      `&client_id=${encodeURIComponent(process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ?? '')}` +
+      `&client_id=${encodeURIComponent(clientId)}` +
       `&redirect_uri=${encodeURIComponent(redirectUri)}` +
       '&scope=openid%20email%20profile';
     const result = await WebBrowser.openAuthSessionAsync(authUrl, redirectUri);

--- a/server.mjs
+++ b/server.mjs
@@ -9,6 +9,11 @@ app.use(express.urlencoded({ extended: true }));
 const CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error('GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set');
+  process.exit(1);
+}
+
 // The redirect URI MUST exactly match one configured in Google Cloud Console
 // This should point back to the Expo app using a custom scheme.
 const REDIRECT_URI = 'myibapp://auth-callback';


### PR DESCRIPTION
## Summary
- add checks for missing Google OAuth client IDs in Expo app and Express server
- document required Google OAuth environment variables
- ignore local .env and provide .env.example

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b414f4e2b083299a298698222c8462