### PR TITLE
feat: add Google OAuth client ID fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=your_client_id
+EXPO_PUBLIC_OPENAI_API_KEY=your_key_here
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ EXPO_PUBLIC_OPENAI_API_KEY=your_key_here npx expo start
 
 ## Google Sign-In
 
-Google authentication requires OAuth credentials. Provide the client ID when starting the Expo app and both the client ID and secret when running the Express backend:
+Google authentication requires OAuth credentials. Provide the client ID when starting the Expo app (or set it in `app.json` under `extra.googleClientId`) and both the client ID and secret when running the Express backend:
 
 ```bash
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=your_client_id npx expo start

--- a/app.json
+++ b/app.json
@@ -37,6 +37,9 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "googleClientId": ""
     }
   }
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { View, Button, StyleSheet, Alert } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
+import Constants from 'expo-constants';
 
 WebBrowser.maybeCompleteAuthSession();
 
 export default function LoginScreen() {
   const handleLogin = async () => {
-    const clientId = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID;
+    const clientId =
+      process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ||
+      (Constants.expoConfig?.extra?.googleClientId as string | undefined);
     if (!clientId) {
       Alert.alert(
         'Missing configuration',


### PR DESCRIPTION
## Summary
- allow Google client ID to be read from app.json `extra.googleClientId`
- document Google auth configuration and expand .env.example

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b41da335c883299d55508c896ffdda