### PR TITLE
Handle Google OAuth outside app and remove home Google sign-in

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -8,11 +8,8 @@ import {
   Modal,
   Switch,
   useWindowDimensions,
-  Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import * as Linking from 'expo-linking';
-import * as WebBrowser from 'expo-web-browser';
 
 import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
@@ -76,36 +73,12 @@ export default function HomeScreen() {
   const [settingsVisible, setSettingsVisible] = useState(false);
   const [isLightMode, setIsLightMode] = useState(false);
   const [activeCard, setActiveCard] = useState(0);
-  const [authToken, setAuthToken] = useState<string | null>(null);
 
   const theme = isLightMode ? Colors.light : Colors.dark;
   const { width } = useWindowDimensions();
   const scrollRef = useRef<ScrollView>(null);
   const styles = useMemo(() => createStyles(theme, width), [theme, width]);
 
-  const handleGoogleSignIn = async () => {
-    try {
-      const result = await WebBrowser.openAuthSessionAsync(
-        'http://localhost:3000/auth/google',
-        'myibapp://auth-callback',
-      );
-      if (result.type === 'success' && result.url) {
-        const { queryParams } = Linking.parse(result.url);
-        if (queryParams?.code) {
-          const response = await fetch('http://localhost:3000/auth/google/token', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ code: String(queryParams.code) }).toString(),
-          });
-          const data = await response.json();
-          setAuthToken(data.access_token);
-          Alert.alert('Logged in', 'Google sign-in successful');
-        }
-      }
-    } catch {
-      Alert.alert('Error', 'Failed to sign in with Google');
-    }
-  };
 
   return (
     <View style={styles.container}>
@@ -120,12 +93,6 @@ export default function HomeScreen() {
           <Text style={styles.headerTitle}>Clarity</Text>
         </View>
 
-        <TouchableOpacity style={styles.googleButton} onPress={handleGoogleSignIn}>
-          <Text style={styles.googleButtonText}>Sign in with Google</Text>
-        </TouchableOpacity>
-        {authToken && (
-          <Text style={styles.loggedInText}>Logged in</Text>
-        )}
 
         <ScrollView
           ref={scrollRef}
@@ -251,7 +218,10 @@ export default function HomeScreen() {
   );
 }
 
-const createStyles = (colors: typeof Colors.dark, width: number) =>
+const createStyles = (
+  colors: typeof Colors.light | typeof Colors.dark,
+  width: number,
+) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -271,23 +241,6 @@ const createStyles = (colors: typeof Colors.dark, width: number) =>
       fontSize: 22,
       fontWeight: 'bold',
       marginLeft: 8,
-    },
-    googleButton: {
-      backgroundColor: '#4285F4',
-      paddingVertical: 10,
-      paddingHorizontal: 16,
-      borderRadius: 4,
-      alignSelf: 'center',
-      marginTop: 20,
-    },
-    googleButtonText: {
-      color: '#fff',
-      fontWeight: '600',
-    },
-    loggedInText: {
-      color: colors.text,
-      textAlign: 'center',
-      marginTop: 10,
     },
     cardCarousel: {
       marginTop: 20,

--- a/app/(tabs)/tutor.tsx
+++ b/app/(tabs)/tutor.tsx
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { WebView } from 'react-native-webview';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as WebBrowser from 'expo-web-browser';
 
 export default function TutorScreen() {
   const insets = useSafeAreaInsets();
+  const webviewRef = useRef<WebView>(null);
+
+  const handleShouldStartLoadWithRequest = (request: any) => {
+    // When the ChatGPT page tries to start Google OAuth inside the WebView,
+    // open it in the system browser instead so Google allows the login.
+    if (request.url.startsWith('https://accounts.google.com')) {
+      WebBrowser.openBrowserAsync(request.url).then(() => {
+        // Reload the ChatGPT page so it picks up any cookies from the browser
+        // session and reflects the authenticated state.
+        webviewRef.current?.reload();
+      });
+      return false;
+    }
+    return true;
+  };
   return (
     <WebView
+      ref={webviewRef}
       source={{ uri: 'https://chatgpt.com/' }}
       style={{ flex: 1, marginTop: insets.top }}
+      onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Open Google OAuth in system browser from Tutor screen and reload WebView with session
- Remove Google sign-in button and related logic from Home screen

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npx tsc --noEmit` (fails: cannot find module and type errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68b4a579b3688329a295b522720e8b00