### PR TITLE
fix: handle Google OAuth session in tutor webview

### DIFF
--- a/app/(tabs)/tutor.tsx
+++ b/app/(tabs)/tutor.tsx
@@ -9,8 +9,15 @@ export default function TutorScreen() {
 
   const handleShouldStartLoadWithRequest = (request: any) => {
     // When the ChatGPT page tries to start Google OAuth inside the WebView,
-    // open it in the system browser instead so Google allows the login.
-    if (request.url.startsWith('https://accounts.google.com')) {
+    // open the flow in the system browser instead so Google allows the login.
+    // We intercept both the initial auth.openai.com request that starts the
+    // OAuth session and the subsequent accounts.google.com URL. Otherwise the
+    // Google callback complains with "invalid session" because the cookie set
+    // by auth.openai.com isn't available in the external browser.
+    if (
+      request.url.startsWith('https://accounts.google.com') ||
+      request.url.startsWith('https://auth.openai.com')
+    ) {
       WebBrowser.openBrowserAsync(request.url).then(() => {
         // Reload the ChatGPT page so it picks up any cookies from the browser
         // session and reflects the authenticated state.


### PR DESCRIPTION
## Summary
- open Google OAuth and auth.openai.com links in system browser to preserve session

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a73752dc8329b230287e04a2c3b8