### PR TITLE
fix: handle Google OAuth session in tutor webview

### DIFF
--- a/app/(tabs)/tutor.tsx
+++ b/app/(tabs)/tutor.tsx
@@ -1,21 +1,33 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
+import { AppState, Linking } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import * as WebBrowser from 'expo-web-browser';
 
 export default function TutorScreen() {
   const insets = useSafeAreaInsets();
   const webviewRef = useRef<WebView>(null);
 
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        webviewRef.current?.reload();
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
   const handleShouldStartLoadWithRequest = (request: any) => {
     // When the ChatGPT page tries to start Google OAuth inside the WebView,
-    // open it in the system browser instead so Google allows the login.
-    if (request.url.startsWith('https://accounts.google.com')) {
-      WebBrowser.openBrowserAsync(request.url).then(() => {
-        // Reload the ChatGPT page so it picks up any cookies from the browser
-        // session and reflects the authenticated state.
-        webviewRef.current?.reload();
-      });
+    // open the flow in the system browser instead so Google allows the login.
+    // We intercept both the initial auth.openai.com request that starts the
+    // OAuth session and the subsequent accounts.google.com URL. Otherwise the
+    // Google callback complains with "invalid session" because the cookie set
+    // by auth.openai.com isn't available in the external browser.
+    if (
+      request.url.startsWith('https://accounts.google.com') ||
+      request.url.startsWith('https://auth.openai.com')
+    ) {
+      Linking.openURL(request.url);
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary
- open OAuth links in external browser so session persists when switching apps
- reload tutor WebView when app returns to foreground

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a73752dc8329b230287e04a2c3b8