### PR TITLE
Fix multi-section drag in notes grid

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -20,6 +20,7 @@ import RenderHTML from 'react-native-render-html';
 import { useLocalSearchParams } from 'expo-router';
 import DraggableFlatList, {
   RenderItemParams,
+  ScaleDecorator,
 } from 'react-native-draggable-flatlist';
 import AIButton from '../../components/AIButton';
 import { subjectData, SubjectInfo } from '@/constants/subjects';
@@ -374,26 +375,28 @@ export default function NotesScreen() {
     }
 
     return (
-      <Animated.View style={[styles.box, { backgroundColor: item.color }, animatedStyle]}>
-        <TouchableOpacity
-          style={styles.subjectDeleteIcon}
-          onPress={() => confirmDeleteSubject(item.key)}
-        >
-          <Ionicons name="close" size={16} color={iconColor} />
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.boxContent}
-          onLongPress={drag}
-          disabled={isActive}
-          onPress={() => openSubject(item)}
-        >
-          <Ionicons name={item.icon} size={32} color={iconColor} />
-          <Text style={styles.boxTitle}>{item.title}</Text>
-          {item.notes.length > 0 && (
-            <Text style={styles.boxNote}>{item.notes.length} notes</Text>
-          )}
-        </TouchableOpacity>
-      </Animated.View>
+      <ScaleDecorator>
+        <Animated.View style={[styles.box, { backgroundColor: item.color }, animatedStyle]}>
+          <TouchableOpacity
+            style={styles.subjectDeleteIcon}
+            onPress={() => confirmDeleteSubject(item.key)}
+          >
+            <Ionicons name="close" size={16} color={iconColor} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.boxContent}
+            onLongPress={drag}
+            disabled={isActive}
+            onPress={() => openSubject(item)}
+          >
+            <Ionicons name={item.icon} size={32} color={iconColor} />
+            <Text style={styles.boxTitle}>{item.title}</Text>
+            {item.notes.length > 0 && (
+              <Text style={styles.boxNote}>{item.notes.length} notes</Text>
+            )}
+          </TouchableOpacity>
+        </Animated.View>
+      </ScaleDecorator>
     );
   };
 
@@ -440,44 +443,46 @@ export default function NotesScreen() {
     } as const;
 
     return (
-      <Animated.View
-        style={[styles.noteCard, { backgroundColor: item.color }, animatedStyle]}
-      >
-        <TouchableOpacity
-          style={styles.noteBody}
-          onPress={() => openNote(item)}
-          onLongPress={drag}
-          disabled={isActive}
+      <ScaleDecorator>
+        <Animated.View
+          style={[styles.noteCard, { backgroundColor: item.color }, animatedStyle]}
         >
-          <Text style={styles.noteTitle}>{item.title}</Text>
-          <Text style={styles.noteDate}>{item.date}</Text>
-          <RenderHTML
-            contentWidth={width}
-            source={{ html: item.text }}
-            baseStyle={styles.noteText}
-            defaultTextProps={{ numberOfLines: 3, ellipsizeMode: 'tail' }}
-          />
-          {item.images?.length ? (
-            item.images.length === 1 ? (
-              <Image
-                source={{ uri: item.images[0] }}
-                style={styles.noteImage}
-                contentFit="contain"
-              />
-            ) : (
-              <View style={styles.imageIconContainer}>
-                <Ionicons name="images" size={20} color={iconColor} />
-              </View>
-            )
-          ) : null}
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.deleteIcon}
-          onPress={() => confirmDeleteNote(item.id)}
-        >
-          <Ionicons name="trash" size={20} color={iconColor} />
-        </TouchableOpacity>
-      </Animated.View>
+          <TouchableOpacity
+            style={styles.noteBody}
+            onPress={() => openNote(item)}
+            onLongPress={drag}
+            disabled={isActive}
+          >
+            <Text style={styles.noteTitle}>{item.title}</Text>
+            <Text style={styles.noteDate}>{item.date}</Text>
+            <RenderHTML
+              contentWidth={width}
+              source={{ html: item.text }}
+              baseStyle={styles.noteText}
+              defaultTextProps={{ numberOfLines: 3, ellipsizeMode: 'tail' }}
+            />
+            {item.images?.length ? (
+              item.images.length === 1 ? (
+                <Image
+                  source={{ uri: item.images[0] }}
+                  style={styles.noteImage}
+                  contentFit="contain"
+                />
+              ) : (
+                <View style={styles.imageIconContainer}>
+                  <Ionicons name="images" size={20} color={iconColor} />
+                </View>
+              )
+            ) : null}
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.deleteIcon}
+            onPress={() => confirmDeleteNote(item.id)}
+          >
+            <Ionicons name="trash" size={20} color={iconColor} />
+          </TouchableOpacity>
+        </Animated.View>
+      </ScaleDecorator>
     );
   };
 


### PR DESCRIPTION
## Summary
- wrap subject and note items with `ScaleDecorator` to ensure only one section is dragged at a time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b596b738d08329b86584833ed20a97