### PR TITLE
Fix notes grid layout

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -886,8 +886,6 @@ const createStyles = () => {
     },
     grid: {
       paddingBottom: 16,
-      flexDirection: 'row',
-      flexWrap: 'wrap',
       borderWidth: 1,
       borderColor: inputBorder,
     },
@@ -903,7 +901,7 @@ const createStyles = () => {
       paddingBottom: 16,
     },
     box: {
-      width: '50%',
+      flex: 1,
       borderWidth: 1,
       borderColor: inputBorder,
       padding: 16,


### PR DESCRIPTION
## Summary
- fix notes grid item sizing by removing flex wrap and using flex-based sizing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59e1396748329b4465b162843f739