### PR TITLE
Arrange notes subjects in two-column grid with note counts

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -290,46 +290,64 @@ export default function NotesScreen() {
           </>
         ) : (
           <View style={styles.subjectGrid}>
-            {subjects.map(sub => (
-              <TouchableOpacity
-                key={sub}
-                style={[styles.subjectCube, { backgroundColor: subjectColors[sub] }]}
-                onPress={() => {
-                  setCurrentSubject(sub);
-                  setQuery('');
-                }}
-              >
-                <TouchableOpacity
-                  style={styles.colorIcon}
-                  onPress={() =>
-                    setColorMenuSubject(
-                      colorMenuSubject === sub ? null : sub,
-                    )
-                  }
-                >
-                  <Ionicons name="color-palette" size={16} color="#fff" />
-                </TouchableOpacity>
-                {colorMenuSubject === sub && (
-                  <View style={styles.colorPicker}>
-                    {colorChoices.map(c => (
-                      <TouchableOpacity
-                        key={c}
-                        style={[styles.colorSwatch, { backgroundColor: c }]}
-                        onPress={() => selectColor(sub, c)}
-                      />
-                    ))}
-                  </View>
-                )}
-                <Text style={styles.subjectText}>{sub}</Text>
-              </TouchableOpacity>
-            ))}
-            <TouchableOpacity
-              style={[styles.subjectCube, styles.addCube]}
-              onPress={() => setAddingSubject(true)}
-            >
-              <Ionicons name="add" size={24} color="#fff" />
-              <Text style={styles.subjectText}>ADD</Text>
-            </TouchableOpacity>
+            {(() => {
+              const items = [...subjects, 'ADD'];
+              if (items.length % 2 !== 0) items.push('PLACEHOLDER');
+              return items.map(sub => {
+                if (sub === 'ADD') {
+                  return (
+                    <TouchableOpacity
+                      key="ADD"
+                      style={[styles.subjectCube, styles.addCube]}
+                      onPress={() => setAddingSubject(true)}
+                    >
+                      <Ionicons name="add" size={24} color="#fff" />
+                      <Text style={styles.subjectText}>ADD</Text>
+                    </TouchableOpacity>
+                  );
+                }
+                if (sub === 'PLACEHOLDER') {
+                  return <View key="placeholder" style={[styles.subjectCube, styles.placeholderCube]} />;
+                }
+                const count = notes.filter(n => n.subject === sub).length;
+                return (
+                  <TouchableOpacity
+                    key={sub}
+                    style={[styles.subjectCube, { backgroundColor: subjectColors[sub] }]}
+                    onPress={() => {
+                      setCurrentSubject(sub);
+                      setQuery('');
+                    }}
+                  >
+                    <TouchableOpacity
+                      style={styles.colorIcon}
+                      onPress={() =>
+                        setColorMenuSubject(
+                          colorMenuSubject === sub ? null : sub,
+                        )
+                      }
+                    >
+                      <Ionicons name="color-palette" size={16} color="#fff" />
+                    </TouchableOpacity>
+                    {colorMenuSubject === sub && (
+                      <View style={styles.colorPicker}>
+                        {colorChoices.map(c => (
+                          <TouchableOpacity
+                            key={c}
+                            style={[styles.colorSwatch, { backgroundColor: c }]}
+                            onPress={() => selectColor(sub, c)}
+                          />
+                        ))}
+                      </View>
+                    )}
+                    <Text style={styles.subjectText}>{sub}</Text>
+                    {count > 0 && (
+                      <Text style={styles.noteCount}>Notes: {count}</Text>
+                    )}
+                  </TouchableOpacity>
+                );
+              });
+            })()}
           </View>
         )}
         <Modal visible={modalVisible} animationType="none">
@@ -471,17 +489,23 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   subjectGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
     paddingHorizontal: 16,
     marginBottom: 16,
   },
   subjectCube: {
-    width: '100%',
+    width: '48%',
     height: 120,
-    borderRadius: 8,
+    borderRadius: 12,
     marginBottom: 16,
     justifyContent: 'center',
     alignItems: 'center',
     position: 'relative',
+  },
+  placeholderCube: {
+    backgroundColor: 'transparent',
   },
   addCube: {
     backgroundColor: '#4b5563',
@@ -513,6 +537,10 @@ const styles = StyleSheet.create({
   subjectText: {
     color: '#fff',
     fontWeight: 'bold',
+  },
+  noteCount: {
+    color: '#fff',
+    marginTop: 4,
   },
   selectedHeader: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- display subjects in two-column grid with consistent spacing
- show note counts under subject names
- style subject tiles with rounded corners and placeholders to keep rows even

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5bc6590508329b39456468a38e6bb