### PR TITLE
Refine subject sections with icons and removal controls

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -92,12 +92,28 @@ export default function NotesScreen() {
     History: '#dc2626',
     Art: '#f59e0b',
   };
-  const [subjectColors, setSubjectColors] = useState<Record<string, string>>(defaultColors);
-  const [colorMenuSubject, setColorMenuSubject] = useState<string | null>(null);
+  const [subjectColors, setSubjectColors] =
+    useState<Record<string, string>>(defaultColors);
 
-  const selectColor = (subject: string, color: string) => {
-    setSubjectColors(prev => ({ ...prev, [subject]: color }));
-    setColorMenuSubject(null);
+  const subjectIcons: Record<string, keyof typeof Ionicons.glyphMap> = {
+    Math: 'calculator',
+    English: 'book',
+    Science: 'flask',
+    History: 'time',
+    Art: 'color-palette',
+  };
+
+  const removeSubject = (subject: string) => {
+    setSubjects(prev => prev.filter(s => s !== subject));
+    setSubjectColors(prev => {
+      const updated = { ...prev };
+      delete updated[subject];
+      return updated;
+    });
+    setNotes(prev => prev.filter(n => n.subject !== subject));
+    if (currentSubject === subject) {
+      setCurrentSubject(null);
+    }
   };
 
   const performSearch = () => {
@@ -320,26 +336,17 @@ export default function NotesScreen() {
                     }}
                   >
                     <TouchableOpacity
-                      style={styles.colorIcon}
-                      onPress={() =>
-                        setColorMenuSubject(
-                          colorMenuSubject === sub ? null : sub,
-                        )
-                      }
+                      style={styles.removeIcon}
+                      onPress={() => removeSubject(sub)}
                     >
-                      <Ionicons name="color-palette" size={16} color="#fff" />
+                      <Ionicons name="close" size={16} color="#fff" />
                     </TouchableOpacity>
-                    {colorMenuSubject === sub && (
-                      <View style={styles.colorPicker}>
-                        {colorChoices.map(c => (
-                          <TouchableOpacity
-                            key={c}
-                            style={[styles.colorSwatch, { backgroundColor: c }]}
-                            onPress={() => selectColor(sub, c)}
-                          />
-                        ))}
-                      </View>
-                    )}
+                    <Ionicons
+                      name={subjectIcons[sub] || 'book'}
+                      size={32}
+                      color="#fff"
+                      style={styles.subjectIcon}
+                    />
                     <Text style={styles.subjectText}>{sub}</Text>
                     {count > 0 && (
                       <Text style={styles.noteCount}>Notes: {count}</Text>
@@ -449,7 +456,10 @@ export default function NotesScreen() {
                       setSubjects([...subjects, name]);
                       setSubjectColors(prev => ({
                         ...prev,
-                        [name]: colorChoices[0],
+                        [name]:
+                          colorChoices[
+                            Math.floor(Math.random() * colorChoices.length)
+                          ],
                       }));
                     }
                     setAddingSubject(false);
@@ -503,6 +513,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     position: 'relative',
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 3,
   },
   placeholderCube: {
     backgroundColor: 'transparent',
@@ -511,28 +525,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#4b5563',
     flexDirection: 'row',
   },
-  colorIcon: {
+  removeIcon: {
     position: 'absolute',
     top: 6,
     right: 6,
   },
-  colorPicker: {
-    position: 'absolute',
-    top: 24,
-    right: 0,
-    backgroundColor: '#fff',
-    padding: 4,
-    borderRadius: 4,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    width: 120,
-    zIndex: 10,
-  },
-  colorSwatch: {
-    width: 20,
-    height: 20,
-    borderRadius: 10,
-    margin: 4,
+  subjectIcon: {
+    marginBottom: 8,
   },
   subjectText: {
     color: '#fff',


### PR DESCRIPTION
## Summary
- Remove subject color picker from notes sections and add icons for each subject
- Provide subject removal button and polished styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5bfc3758883298ae9e4ecec9ef442