### PR TITLE
Add note deletion confirmation and global theme support

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -14,6 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
 import { subjectData, SubjectInfo } from '@/constants/subjects';
+import { useThemeContext } from '@/context/ThemeContext';
 
 const cardData = [
   {
@@ -71,10 +72,10 @@ export default function HomeScreen() {
   const [selectedSubject, setSelectedSubject] = useState<SubjectInfo>(subjectData[0]);
   const [showSubjects, setShowSubjects] = useState(false);
   const [settingsVisible, setSettingsVisible] = useState(false);
-  const [isLightMode, setIsLightMode] = useState(false);
+  const { colorScheme, setColorScheme } = useThemeContext();
   const [activeCard, setActiveCard] = useState(0);
 
-  const theme = isLightMode ? Colors.light : Colors.dark;
+  const theme = colorScheme === 'light' ? Colors.light : Colors.dark;
   const { width } = useWindowDimensions();
   const scrollRef = useRef<ScrollView>(null);
   const styles = useMemo(() => createStyles(theme, width), [theme, width]);
@@ -177,7 +178,10 @@ export default function HomeScreen() {
             <Text style={styles.settingsTitle}>Settings</Text>
             <View style={styles.settingRow}>
               <Text style={styles.settingText}>Light Mode</Text>
-              <Switch value={isLightMode} onValueChange={setIsLightMode} />
+              <Switch
+                value={colorScheme === 'light'}
+                onValueChange={v => setColorScheme(v ? 'light' : 'dark')}
+              />
             </View>
             <Text style={styles.settingPlaceholder}>
               More customization options coming soon...

--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -15,6 +15,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  Alert,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -26,6 +27,8 @@ import {
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
 import { Ionicons } from '@expo/vector-icons';
+import { Colors } from '@/constants/Colors';
+import { useThemeContext } from '@/context/ThemeContext';
 
 type Attachment = {
   id: string;
@@ -56,6 +59,8 @@ const GRADIENT_COLORS = ['#4b1e7e', '#00081f'];
 const stripHtml = (html: string) => html.replace(/<[^>]+>/g, '');
 
 export default function NotesScreen() {
+  const { colorScheme } = useThemeContext();
+  const theme = Colors[colorScheme];
   const [notes, setNotes] = useState<Note[]>([]);
   const [query, setQuery] = useState('');
   const [current, setCurrent] = useState<Note | null>(null);
@@ -85,6 +90,7 @@ export default function NotesScreen() {
     '#f97316',
     '#84cc16',
   ];
+  const [selectedColor, setSelectedColor] = useState(colorChoices[0]);
   const defaultColors: Record<string, string> = {
     Math: '#7c3aed',
     English: '#2563eb',
@@ -204,7 +210,15 @@ export default function NotesScreen() {
   };
 
   const deleteNote = (id: string) => {
-    setNotes(prev => prev.filter(n => n.id !== id));
+    Alert.alert('Delete', 'Are you sure you want to delete this subject?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () =>
+          setNotes(prev => prev.filter(n => n.id !== id)),
+      },
+    ]);
   };
 
   const addImage = async () => {
@@ -227,14 +241,17 @@ export default function NotesScreen() {
   return (
     <LinearGradient colors={GRADIENT_COLORS} style={styles.gradient}>
       <SafeAreaView style={styles.container}>
-        <Text style={styles.logo}>CLARITY</Text>
+        <Text style={[styles.logo, { color: theme.text }]}>CLARITY</Text>
         <TextInput
           placeholder="Search notes"
           placeholderTextColor="#888"
           value={query}
           onChangeText={setQuery}
           onSubmitEditing={performSearch}
-          style={styles.search}
+          style={[
+            styles.search,
+            { backgroundColor: theme.card, color: theme.text },
+          ]}
         />
         {searchMode ? (
           <View style={{ flex: 1 }}>
@@ -245,9 +262,9 @@ export default function NotesScreen() {
                   setQuery('');
                 }}
               >
-                <Ionicons name="arrow-back" size={24} color="#fff" />
+                <Ionicons name="arrow-back" size={24} color={theme.text} />
               </TouchableOpacity>
-              <Text style={styles.selectedTitle}>Results</Text>
+              <Text style={[styles.selectedTitle, { color: theme.text }]}>Results</Text>
             </View>
             <FlatList
               data={results}
@@ -255,14 +272,21 @@ export default function NotesScreen() {
               contentContainerStyle={{ padding: 16 }}
               renderItem={({ item }) => (
                 <TouchableOpacity
-                  style={styles.noteCard}
+                  style={[styles.noteCard, { backgroundColor: theme.card }]}
                   onPress={() => openEdit(item)}
                 >
-                  <Text style={styles.noteTitle}>{item.title || 'Untitled'}</Text>
-                  <Text numberOfLines={2} style={styles.notePreview}>
+                  <Text style={[styles.noteTitle, { color: theme.text }]}>
+                    {item.title || 'Untitled'}
+                  </Text>
+                  <Text
+                    numberOfLines={2}
+                    style={[styles.notePreview, { color: theme.text }]}
+                  >
                     {stripHtml(item.content)}
                   </Text>
-                  <Text style={styles.resultSubject}>{item.subject}</Text>
+                  <Text style={[styles.resultSubject, { color: theme.text }]}> 
+                    {item.subject}
+                  </Text>
                 </TouchableOpacity>
               )}
             />
@@ -276,9 +300,9 @@ export default function NotesScreen() {
                   setQuery('');
                 }}
               >
-                <Ionicons name="arrow-back" size={24} color="#fff" />
+                <Ionicons name="arrow-back" size={24} color={theme.text} />
               </TouchableOpacity>
-              <Text style={styles.selectedTitle}>{currentSubject}</Text>
+              <Text style={[styles.selectedTitle, { color: theme.text }]}>{currentSubject}</Text>
             </View>
             <FlatList
               data={filtered.sort((a, b) => b.updatedAt - a.updatedAt)}
@@ -286,12 +310,17 @@ export default function NotesScreen() {
               contentContainerStyle={{ padding: 16 }}
               renderItem={({ item }) => (
                 <TouchableOpacity
-                  style={styles.noteCard}
+                  style={[styles.noteCard, { backgroundColor: theme.card }]}
                   onPress={() => openEdit(item)}
                   onLongPress={() => deleteNote(item.id)}
                 >
-                  <Text style={styles.noteTitle}>{item.title || 'Untitled'}</Text>
-                  <Text numberOfLines={2} style={styles.notePreview}>
+                  <Text style={[styles.noteTitle, { color: theme.text }]}>
+                    {item.title || 'Untitled'}
+                  </Text>
+                  <Text
+                    numberOfLines={2}
+                    style={[styles.notePreview, { color: theme.text }]}
+                  >
                     {stripHtml(item.content)}
                   </Text>
                 </TouchableOpacity>
@@ -315,7 +344,10 @@ export default function NotesScreen() {
                     <TouchableOpacity
                       key="ADD"
                       style={[styles.subjectCube, styles.addCube]}
-                      onPress={() => setAddingSubject(true)}
+                      onPress={() => {
+                        setSelectedColor(colorChoices[0]);
+                        setAddingSubject(true);
+                      }}
                     >
                       <Ionicons name="add" size={24} color="#fff" />
                       <Text style={styles.subjectText}>ADD</Text>
@@ -367,7 +399,8 @@ export default function NotesScreen() {
                 <ScrollView contentContainerStyle={{ padding: 16 }}>
                   <TextInput
                     placeholder="Title"
-                    style={styles.titleInput}
+                    placeholderTextColor="#888"
+                    style={[styles.titleInput, { backgroundColor: theme.card, color: theme.text }]}
                     value={current?.title}
                     onChangeText={t =>
                       setCurrent(c => (c ? { ...c, title: t } : c))
@@ -375,7 +408,7 @@ export default function NotesScreen() {
                   />
                   <RichEditor
                     ref={editorRef}
-                    style={styles.editor}
+                    style={[styles.editor, { backgroundColor: theme.card, color: theme.text }]}
                     initialContentHTML={current?.content}
                     placeholder="Start writing..."
                     onChange={html =>
@@ -405,9 +438,9 @@ export default function NotesScreen() {
                     ))}
                     <TouchableOpacity
                       onPress={addImage}
-                      style={styles.addAttachment}
+                      style={[styles.addAttachment, { backgroundColor: theme.card }]}
                     >
-                      <Text style={{ fontSize: 32 }}>+</Text>
+                      <Text style={{ fontSize: 32, color: theme.text }}>+</Text>
                     </TouchableOpacity>
                   </View>
                 </ScrollView>
@@ -431,10 +464,27 @@ export default function NotesScreen() {
         </Modal>
         <Modal visible={addingSubject} transparent animationType="fade">
           <View style={styles.addModal}>
-            <View style={styles.addModalContent}>
+            <View style={[styles.addModalContent, { backgroundColor: theme.card }]}> 
+              <View style={styles.colorRow}>
+                {colorChoices.map(c => (
+                  <TouchableOpacity
+                    key={c}
+                    style={[
+                      styles.colorOption,
+                      {
+                        backgroundColor: c,
+                        borderColor: theme.text,
+                        borderWidth: selectedColor === c ? 2 : 0,
+                      },
+                    ]}
+                    onPress={() => setSelectedColor(c)}
+                  />
+                ))}
+              </View>
               <TextInput
                 placeholder="Section name"
-                style={styles.titleInput}
+                placeholderTextColor="#888"
+                style={[styles.titleInput, { backgroundColor: theme.card, color: theme.text }]}
                 value={newSubject}
                 onChangeText={setNewSubject}
               />
@@ -456,10 +506,7 @@ export default function NotesScreen() {
                       setSubjects([...subjects, name]);
                       setSubjectColors(prev => ({
                         ...prev,
-                        [name]:
-                          colorChoices[
-                            Math.floor(Math.random() * colorChoices.length)
-                          ],
+                        [name]: selectedColor,
                       }));
                     }
                     setAddingSubject(false);
@@ -496,7 +543,7 @@ const styles = StyleSheet.create({
     padding: 8,
     borderWidth: 1,
     borderRadius: 8,
-    backgroundColor: '#fff',
+    backgroundColor: '#1e1e1e',
   },
   subjectGrid: {
     flexDirection: 'row',
@@ -554,7 +601,7 @@ const styles = StyleSheet.create({
     marginLeft: 8,
   },
   noteCard: {
-    backgroundColor: '#fff',
+    backgroundColor: '#1e1e1e',
     padding: 12,
     borderRadius: 8,
     marginBottom: 12,
@@ -570,7 +617,7 @@ const styles = StyleSheet.create({
   },
   notePreview: {
     fontSize: 14,
-    color: '#555',
+    color: '#fff',
   },
   fab: {
     position: 'absolute',
@@ -618,7 +665,7 @@ const styles = StyleSheet.create({
   addAttachment: {
     width: 80,
     height: 80,
-    backgroundColor: '#e2e8f0',
+    backgroundColor: '#1e1e1e',
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: 4,
@@ -661,9 +708,19 @@ const styles = StyleSheet.create({
   },
   addModalContent: {
     width: '80%',
-    backgroundColor: '#fff',
+    backgroundColor: '#1e1e1e',
     borderRadius: 8,
     padding: 16,
+  },
+  colorRow: {
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  colorOption: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    marginRight: 8,
   },
 });
 

--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -10,6 +10,8 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
+import { Colors } from '@/constants/Colors';
+import { useThemeContext } from '@/context/ThemeContext';
 
 const eventColorOptions = [
   '#FF6633', '#FFB399', '#FF33FF', '#FFFF99', '#00B3E6', '#E6B333',
@@ -31,6 +33,8 @@ type DayData = {
 };
 
 export default function ScheduleScreen() {
+  const { colorScheme } = useThemeContext();
+  const theme = Colors[colorScheme];
   const [currentDate, setCurrentDate] = useState(new Date());
   const [schedule, setSchedule] = useState<Record<string, DayData>>({});
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -104,20 +108,29 @@ export default function ScheduleScreen() {
   };
 
   return (
-    <LinearGradient colors={["#2e1065", "#000"]} style={styles.container}>
+    <LinearGradient
+      colors={
+        colorScheme === 'light' ? ['#ffffff', '#e5e7eb'] : ['#2e1065', '#000']
+      }
+      style={styles.container}
+    >
       <View style={styles.header}>
         <TouchableOpacity onPress={() => setCurrentDate(new Date(year, month - 1, 1))}>
-          <Ionicons name="chevron-back" size={24} color="#fff" />
+          <Ionicons name="chevron-back" size={24} color={theme.text} />
         </TouchableOpacity>
-        <Text style={styles.title}>{getMonthName(currentDate)} {year}</Text>
+        <Text style={[styles.title, { color: theme.text }]}>
+          {getMonthName(currentDate)} {year}
+        </Text>
         <TouchableOpacity onPress={() => setCurrentDate(new Date(year, month + 1, 1))}>
-          <Ionicons name="chevron-forward" size={24} color="#fff" />
+          <Ionicons name="chevron-forward" size={24} color={theme.text} />
         </TouchableOpacity>
       </View>
 
       <View style={styles.weekRow}>
         {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(d => (
-          <Text key={d} style={styles.weekDay}>{d}</Text>
+          <Text key={d} style={[styles.weekDay, { color: theme.text }]}>
+            {d}
+          </Text>
         ))}
       </View>
 
@@ -150,11 +163,15 @@ export default function ScheduleScreen() {
                     />
                   )}
                   {isToday ? (
-                    <View style={styles.todayCircle}>
-                      <Text style={styles.dayText}>{date.getDate()}</Text>
+                    <View style={[styles.todayCircle, { borderColor: theme.text }]}>
+                      <Text style={[styles.dayText, { color: theme.text }]}> 
+                        {date.getDate()}
+                      </Text>
                     </View>
                   ) : (
-                    <Text style={styles.dayText}>{date.getDate()}</Text>
+                    <Text style={[styles.dayText, { color: theme.text }]}>
+                      {date.getDate()}
+                    </Text>
                   )}
                 </>
               )}
@@ -168,29 +185,33 @@ export default function ScheduleScreen() {
         animationType="slide"
         onRequestClose={() => setSelectedDate(null)}
       >
-        <View style={styles.modalContainer}>
+        <View style={[styles.modalContainer, { backgroundColor: theme.card }]}> 
           {selectedDate && (
             <>
-              <Text style={styles.modalTitle}>{selectedDate.toDateString()}</Text>
+              <Text style={[styles.modalTitle, { color: theme.text }]}> 
+                {selectedDate.toDateString()}
+              </Text>
               <ScrollView style={styles.notesList}>
                 {currentNotes.map((note, idx) => (
                   <View key={idx} style={styles.noteItem}>
-                    <Text style={styles.noteText}>{note}</Text>
+                    <Text style={[styles.noteText, { color: theme.text }]}> 
+                      {note}
+                    </Text>
                     <TouchableOpacity onPress={() => deleteNote(idx)}>
-                      <Ionicons name="trash" size={16} color="#fff" />
+                      <Ionicons name="trash" size={16} color={theme.text} />
                     </TouchableOpacity>
                   </View>
                 ))}
               </ScrollView>
               <TextInput
-                style={styles.input}
+                style={[styles.input, { backgroundColor: theme.card, color: theme.text, borderColor: theme.text }]}
                 placeholder="New note"
                 placeholderTextColor="#aaa"
                 value={newNote}
                 onChangeText={setNewNote}
               />
               <TouchableOpacity style={styles.addButton} onPress={addNote}>
-                <Text style={styles.addButtonText}>Add Note</Text>
+                <Text style={[styles.addButtonText, { color: theme.text }]}>Add Note</Text>
               </TouchableOpacity>
 
               <ScrollView style={styles.eventsList}>
@@ -199,15 +220,17 @@ export default function ScheduleScreen() {
                     <View
                       style={[styles.eventColor, { backgroundColor: ev.color }]}
                     />
-                    <Text style={styles.eventText}>{ev.text}</Text>
+                    <Text style={[styles.eventText, { color: theme.text }]}>
+                      {ev.text}
+                    </Text>
                     <TouchableOpacity onPress={() => deleteEvent(idx)}>
-                      <Ionicons name="trash" size={16} color="#fff" />
+                      <Ionicons name="trash" size={16} color={theme.text} />
                     </TouchableOpacity>
                   </View>
                 ))}
               </ScrollView>
               <TextInput
-                style={styles.input}
+                style={[styles.input, { backgroundColor: theme.card, color: theme.text, borderColor: theme.text }]}
                 placeholder="New event"
                 placeholderTextColor="#aaa"
                 value={newEvent}
@@ -224,24 +247,27 @@ export default function ScheduleScreen() {
                     style={[
                       styles.colorOption,
                       { backgroundColor: color },
-                      newEventColor === color && styles.selectedColor,
+                      newEventColor === color && {
+                        borderWidth: 2,
+                        borderColor: theme.text,
+                      },
                     ]}
                     onPress={() => setNewEventColor(color)}
                   />
                 ))}
               </ScrollView>
               <TouchableOpacity style={styles.addButton} onPress={addEvent}>
-                <Text style={styles.addButtonText}>Add Event</Text>
+                <Text style={[styles.addButtonText, { color: theme.text }]}>Add Event</Text>
               </TouchableOpacity>
               <View style={styles.modalButtons}>
                 <TouchableOpacity style={styles.saveButton} onPress={saveDay}>
-                  <Text style={styles.saveButtonText}>Save</Text>
+                  <Text style={[styles.saveButtonText, { color: theme.text }]}>Save</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={styles.cancelButton}
                   onPress={() => setSelectedDate(null)}
                 >
-                  <Text style={styles.saveButtonText}>Close</Text>
+                  <Text style={[styles.saveButtonText, { color: theme.text }]}>Close</Text>
                 </TouchableOpacity>
               </View>
             </>
@@ -352,10 +378,6 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 12,
     marginRight: 8,
-  },
-  selectedColor: {
-    borderWidth: 2,
-    borderColor: '#fff',
   },
   notesList: {
     maxHeight: 120,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,14 @@
-import { DarkTheme, ThemeProvider } from '@react-navigation/native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider as NavigationThemeProvider,
+} from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
+import { ThemeProvider, useThemeContext } from '@/context/ThemeContext';
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -17,13 +22,22 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <ThemeProvider value={DarkTheme}>
-        <Stack initialRouteName="(tabs)">
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="light" />
+      <ThemeProvider>
+        <RootLayoutNav />
       </ThemeProvider>
     </GestureHandlerRootView>
+  );
+}
+
+function RootLayoutNav() {
+  const { colorScheme } = useThemeContext();
+  return (
+    <NavigationThemeProvider value={colorScheme === 'light' ? DefaultTheme : DarkTheme}>
+      <Stack initialRouteName="(tabs)">
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar style={colorScheme === 'light' ? 'dark' : 'light'} />
+    </NavigationThemeProvider>
   );
 }

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { ColorSchemeName } from 'react-native';
+
+export type ThemeContextType = {
+  colorScheme: NonNullable<ColorSchemeName>;
+  setColorScheme: (scheme: NonNullable<ColorSchemeName>) => void;
+};
+
+export const ThemeContext = createContext<ThemeContextType>({
+  colorScheme: 'dark',
+  setColorScheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [colorScheme, setColorScheme] = useState<NonNullable<ColorSchemeName>>('dark');
+
+  return (
+    <ThemeContext.Provider value={{ colorScheme, setColorScheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useThemeContext() {
+  return useContext(ThemeContext);
+}

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,6 +1,9 @@
 import { useColorScheme as _useColorScheme } from 'react-native';
+import { useContext } from 'react';
+import { ThemeContext } from '@/context/ThemeContext';
 
-// Return the device color scheme, defaulting to light when unavailable.
+// Return the chosen color scheme or fall back to the device preference.
 export function useColorScheme() {
-  return _useColorScheme() ?? 'light';
+  const { colorScheme } = useContext(ThemeContext);
+  return colorScheme ?? _useColorScheme() ?? 'light';
 }


### PR DESCRIPTION
## Summary
- confirm note deletion with safety prompt
- allow choosing colors when creating sections and match note backgrounds to theme
- implement global light/dark theme toggle and apply it across screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5c8c4d7748329877168a5c746c957