### PR TITLE
Add light-mode gradient and align home background

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -10,6 +10,7 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
 
 import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
@@ -81,7 +82,10 @@ export default function HomeScreen() {
 
 
   return (
-    <View style={styles.container}>
+    <LinearGradient
+      colors={isLightMode ? ['#add8e6', '#9370db'] : ['#2e1065', '#000000']}
+      style={styles.container}
+    >
       <ScrollView
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
@@ -215,7 +219,7 @@ export default function HomeScreen() {
           </View>
         </TouchableOpacity>
       </Modal>
-    </View>
+    </LinearGradient>
   );
 }
 
@@ -226,7 +230,6 @@ const createStyles = (
   StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: colors.background,
     },
     content: {
       paddingHorizontal: 20,

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -2,25 +2,26 @@
  * Color palette for the app supporting light and dark modes.
  */
 
-const tintColor = '#9c5dfc';
+const darkTintColor = '#9c5dfc';
+const lightTintColor = '#9370db';
 
 export const Colors = {
   light: {
     text: '#000000',
-    background: '#ffffff',
-    card: '#f2f2f2',
-    tint: tintColor,
+    background: '#add8e6',
+    card: '#d0e1ff',
+    tint: lightTintColor,
     icon: '#555555',
     tabIconDefault: '#555555',
-    tabIconSelected: tintColor,
+    tabIconSelected: lightTintColor,
   },
   dark: {
     text: '#ffffff',
     background: '#121212',
     card: '#1e1e1e',
-    tint: tintColor,
+    tint: darkTintColor,
     icon: '#9a9a9a',
     tabIconDefault: '#9a9a9a',
-    tabIconSelected: tintColor,
+    tabIconSelected: darkTintColor,
   },
 } as const;


### PR DESCRIPTION
## Summary
- Wrap Home screen in gradient to match Notes screen
- Introduce light-mode palette with light blue to mid purple gradient

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b729c9c4d08329b48fdfbd8951b87c