### PR TITLE
Add global theme context with light mode support

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 // Animated icon for the Tutor tab.
 function TutorIcon({ color, focused }: { color: string; focused: boolean }) {
@@ -37,12 +38,13 @@ function TutorIcon({ color, focused }: { color: string; focused: boolean }) {
 
 export default function TabLayout() {
   const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme();
 
   return (
     <Tabs
       initialRouteName="home"
       screenOptions={{
-        tabBarActiveTintColor: Colors.dark.tint,
+        tabBarActiveTintColor: Colors[colorScheme].tint,
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -15,6 +15,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
 import { subjectData, SubjectInfo } from '@/constants/subjects';
+import { useColorScheme, useToggleColorScheme } from '@/hooks/useColorScheme';
 
 const cardData = [
   {
@@ -72,10 +73,11 @@ export default function HomeScreen() {
   const [selectedSubject, setSelectedSubject] = useState<SubjectInfo>(subjectData[0]);
   const [showSubjects, setShowSubjects] = useState(false);
   const [settingsVisible, setSettingsVisible] = useState(false);
-  const [isLightMode, setIsLightMode] = useState(false);
   const [activeCard, setActiveCard] = useState(0);
 
-  const theme = isLightMode ? Colors.light : Colors.dark;
+  const colorScheme = useColorScheme();
+  const toggleColorScheme = useToggleColorScheme();
+  const theme = Colors[colorScheme];
   const { width } = useWindowDimensions();
   const scrollRef = useRef<ScrollView>(null);
   const styles = useMemo(() => createStyles(theme, width), [theme, width]);
@@ -83,7 +85,11 @@ export default function HomeScreen() {
 
   return (
     <LinearGradient
-      colors={isLightMode ? ['#add8e6', '#9370db'] : ['#2e1065', '#000000']}
+      colors={
+        colorScheme === 'light'
+          ? ['#add8e6', '#9370db']
+          : ['#2e1065', '#000000']
+      }
       style={styles.container}
     >
       <ScrollView
@@ -182,7 +188,10 @@ export default function HomeScreen() {
             <Text style={styles.settingsTitle}>Settings</Text>
             <View style={styles.settingRow}>
               <Text style={styles.settingText}>Light Mode</Text>
-              <Switch value={isLightMode} onValueChange={setIsLightMode} />
+              <Switch
+                value={colorScheme === 'light'}
+                onValueChange={toggleColorScheme}
+              />
             </View>
             <Text style={styles.settingPlaceholder}>
               More customization options coming soon...

--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -30,6 +30,8 @@ import DraggableFlatList, {
 } from 'react-native-draggable-flatlist';
 import AIButton from '../../components/AIButton';
 import { subjectData, SubjectInfo } from '@/constants/subjects';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 type Note = {
   id: string;
@@ -66,6 +68,7 @@ const colorOptions = [
 const initialSubjects: Subject[] = subjectData.map(s => ({ ...s, notes: [] }));
 
 export default function NotesScreen() {
+  const colorScheme = useColorScheme();
   const [subjects, setSubjects] = useState<Subject[]>(initialSubjects);
   const [active, setActive] = useState<Subject | null>(null);
   const [noteModalVisible, setNoteModalVisible] = useState(false);
@@ -84,13 +87,17 @@ export default function NotesScreen() {
   const [subjectError, setSubjectError] = useState<string | null>(null);
   const [infoLoading, setInfoLoading] = useState(false);
   const [infoError, setInfoError] = useState<string | null>(null);
-  const styles = useMemo(() => createStyles(), []);
-  const textColor = '#fff';
+  const styles = useMemo(() => createStyles(colorScheme), [colorScheme]);
+  const textColor = Colors[colorScheme].text;
   const iconColor = textColor;
   const richText = useRef<RichEditor>(null);
   const { width } = useWindowDimensions();
   const { subject: subjectParam } = useLocalSearchParams<{ subject?: string }>();
   const router = useRouter();
+  const gradientColors =
+    colorScheme === 'light'
+      ? ['#add8e6', '#9370db']
+      : ['#2e1065', '#000000'];
 
   const stripHtml = (html: string) => html.replace(/<[^>]+>/g, '');
   const filteredNotes = useMemo(
@@ -500,10 +507,7 @@ export default function NotesScreen() {
   );
 
   return (
-    <LinearGradient
-      colors={['#2e1065', '#000000']}
-      style={styles.container}
-    >
+    <LinearGradient colors={gradientColors} style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>NOTES</Text>
         <TouchableOpacity
@@ -522,7 +526,11 @@ export default function NotesScreen() {
       />
       {subjectError && <Text style={styles.errorText}>{subjectError}</Text>}
       {subjectLoading && (
-        <ActivityIndicator size="small" color="#fff" style={styles.loading} />
+        <ActivityIndicator
+          size="small"
+          color={textColor}
+          style={styles.loading}
+        />
       )}
       {searchQuery ? (
         <ScrollView contentContainerStyle={styles.searchResults}>
@@ -647,7 +655,11 @@ export default function NotesScreen() {
           </View>
           {infoError && <Text style={styles.errorText}>{infoError}</Text>}
           {infoLoading && (
-            <ActivityIndicator size="small" color="#fff" style={styles.loading} />
+            <ActivityIndicator
+              size="small"
+              color={textColor}
+              style={styles.loading}
+            />
           )}
           <View style={styles.noteModalButtons}>
             <TouchableOpacity style={styles.saveButton} onPress={handleAddSubject}>
@@ -839,14 +851,16 @@ export default function NotesScreen() {
   );
 }
 
-const createStyles = () => {
-  const textColor = '#fff';
-  const secondaryText = '#ddd';
-  const background = '#1a1a40';
-  const toggleBg = '#2e1065';
-  const inputBorder = '#444';
-  const selectedBorder = '#fff';
-  const cancelBg = '#333';
+const createStyles = (colorScheme: 'light' | 'dark') => {
+  const theme = Colors[colorScheme];
+  const isLight = colorScheme === 'light';
+  const textColor = theme.text;
+  const secondaryText = isLight ? '#333' : '#ddd';
+  const background = theme.background;
+  const toggleBg = theme.card;
+  const inputBorder = isLight ? '#ccc' : '#444';
+  const selectedBorder = theme.text;
+  const cancelBg = isLight ? '#e5e5e5' : '#333';
   return StyleSheet.create({
     container: {
       flex: 1,
@@ -1024,7 +1038,7 @@ const createStyles = () => {
       color: textColor,
     },
     closeButton: {
-      backgroundColor: '#2e1065',
+      backgroundColor: theme.tint,
       padding: 16,
       alignItems: 'center',
     },
@@ -1107,7 +1121,7 @@ const createStyles = () => {
       marginTop: 24,
     },
     saveButton: {
-      backgroundColor: '#2e1065',
+      backgroundColor: theme.tint,
       padding: 16,
       borderRadius: 8,
     },

--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   StyleSheet,
   Text,
@@ -10,6 +10,8 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 const eventColorOptions = [
   '#FF6633', '#FFB399', '#FF33FF', '#FFFF99', '#00B3E6', '#E6B333',
@@ -39,6 +41,13 @@ export default function ScheduleScreen() {
   const [currentEvents, setCurrentEvents] = useState<Event[]>([]);
   const [newEvent, setNewEvent] = useState('');
   const [newEventColor, setNewEventColor] = useState(eventColorOptions[0]);
+  const colorScheme = useColorScheme();
+  const styles = useMemo(() => createStyles(colorScheme), [colorScheme]);
+  const textColor = Colors[colorScheme].text;
+  const gradientColors =
+    colorScheme === 'light'
+      ? ['#add8e6', '#9370db']
+      : ['#2e1065', '#000'];
 
   const month = currentDate.getMonth();
   const year = currentDate.getFullYear();
@@ -104,14 +113,16 @@ export default function ScheduleScreen() {
   };
 
   return (
-    <LinearGradient colors={["#2e1065", "#000"]} style={styles.container}>
+    <LinearGradient colors={gradientColors} style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => setCurrentDate(new Date(year, month - 1, 1))}>
-          <Ionicons name="chevron-back" size={24} color="#fff" />
+          <Ionicons name="chevron-back" size={24} color={textColor} />
         </TouchableOpacity>
-        <Text style={styles.title}>{getMonthName(currentDate)} {year}</Text>
+        <Text style={styles.title}>
+          {getMonthName(currentDate)} {year}
+        </Text>
         <TouchableOpacity onPress={() => setCurrentDate(new Date(year, month + 1, 1))}>
-          <Ionicons name="chevron-forward" size={24} color="#fff" />
+          <Ionicons name="chevron-forward" size={24} color={textColor} />
         </TouchableOpacity>
       </View>
 
@@ -177,7 +188,7 @@ export default function ScheduleScreen() {
                   <View key={idx} style={styles.noteItem}>
                     <Text style={styles.noteText}>{note}</Text>
                     <TouchableOpacity onPress={() => deleteNote(idx)}>
-                      <Ionicons name="trash" size={16} color="#fff" />
+                      <Ionicons name="trash" size={16} color={textColor} />
                     </TouchableOpacity>
                   </View>
                 ))}
@@ -201,7 +212,7 @@ export default function ScheduleScreen() {
                     />
                     <Text style={styles.eventText}>{ev.text}</Text>
                     <TouchableOpacity onPress={() => deleteEvent(idx)}>
-                      <Ionicons name="trash" size={16} color="#fff" />
+                      <Ionicons name="trash" size={16} color={textColor} />
                     </TouchableOpacity>
                   </View>
                 ))}
@@ -252,156 +263,157 @@ export default function ScheduleScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, paddingTop: 60 },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    marginBottom: 16,
-  },
-  title: {
-    color: '#fff',
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-  weekRow: {
-    flexDirection: 'row',
-  },
-  weekDay: {
-    flex: 1,
-    textAlign: 'center',
-    color: '#fff',
-    fontWeight: '600',
-  },
-  calendar: {
-    flex: 1,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-  },
-  dayCell: {
-    width: '14.2857%',
-    height: '16.66%',
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-    overflow: 'hidden',
-  },
-  dayText: {
-    color: '#fff',
-  },
-  eventBackgroundContainer: {
-    ...StyleSheet.absoluteFillObject,
-    flexDirection: 'row',
-    borderRadius: 8,
-  },
-  todayCircle: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    borderWidth: 2,
-    borderColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  modalContainer: {
-    flex: 1,
-    backgroundColor: '#1a1a40',
-    padding: 16,
-    paddingTop: 60,
-  },
-  modalTitle: {
-    color: '#fff',
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 16,
-  },
-  input: {
-    borderColor: '#444',
-    borderWidth: 1,
-    borderRadius: 8,
-    padding: 8,
-    color: '#fff',
-    marginBottom: 12,
-  },
-  eventsList: {
-    maxHeight: 120,
-    marginBottom: 12,
-  },
-  eventItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  eventColor: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    marginRight: 6,
-  },
-  eventText: {
-    color: '#fff',
-    flex: 1,
-  },
-  colorOptions: {
-    marginBottom: 12,
-  },
-  colorOption: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    marginRight: 8,
-  },
-  selectedColor: {
-    borderWidth: 2,
-    borderColor: '#fff',
-  },
-  notesList: {
-    maxHeight: 120,
-    marginBottom: 12,
-  },
-  noteItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 4,
-  },
-  noteText: {
-    color: '#fff',
-    flex: 1,
-    marginRight: 6,
-  },
-  addButton: {
-    backgroundColor: '#2e1065',
-    padding: 8,
-    borderRadius: 8,
-    alignItems: 'center',
-    marginBottom: 12,
-  },
-  addButtonText: {
-    color: '#fff',
-  },
-  modalButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  saveButton: {
-    backgroundColor: '#2e1065',
-    padding: 12,
-    borderRadius: 8,
-    flex: 1,
-    marginRight: 8,
-    alignItems: 'center',
-  },
-  cancelButton: {
-    backgroundColor: '#333',
-    padding: 12,
-    borderRadius: 8,
-    flex: 1,
-    alignItems: 'center',
-  },
-  saveButtonText: {
-    color: '#fff',
-  },
-});
+const createStyles = (colorScheme: 'light' | 'dark') =>
+  StyleSheet.create({
+    container: { flex: 1, paddingTop: 60 },
+    header: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingHorizontal: 16,
+      marginBottom: 16,
+    },
+    title: {
+      color: Colors[colorScheme].text,
+      fontSize: 20,
+      fontWeight: 'bold',
+    },
+    weekRow: {
+      flexDirection: 'row',
+    },
+    weekDay: {
+      flex: 1,
+      textAlign: 'center',
+      color: Colors[colorScheme].text,
+      fontWeight: '600',
+    },
+    calendar: {
+      flex: 1,
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+    },
+    dayCell: {
+      width: '14.2857%',
+      height: '16.66%',
+      borderRadius: 8,
+      alignItems: 'center',
+      justifyContent: 'center',
+      overflow: 'hidden',
+    },
+    dayText: {
+      color: Colors[colorScheme].text,
+    },
+    eventBackgroundContainer: {
+      ...StyleSheet.absoluteFillObject,
+      flexDirection: 'row',
+      borderRadius: 8,
+    },
+    todayCircle: {
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+      borderWidth: 2,
+      borderColor: Colors[colorScheme].text,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    modalContainer: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+      padding: 16,
+      paddingTop: 60,
+    },
+    modalTitle: {
+      color: Colors[colorScheme].text,
+      fontSize: 20,
+      fontWeight: '600',
+      marginBottom: 16,
+    },
+    input: {
+      borderColor: colorScheme === 'light' ? '#ccc' : '#444',
+      borderWidth: 1,
+      borderRadius: 8,
+      padding: 8,
+      color: Colors[colorScheme].text,
+      marginBottom: 12,
+    },
+    eventsList: {
+      maxHeight: 120,
+      marginBottom: 12,
+    },
+    eventItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    eventColor: {
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      marginRight: 6,
+    },
+    eventText: {
+      color: Colors[colorScheme].text,
+      flex: 1,
+    },
+    colorOptions: {
+      marginBottom: 12,
+    },
+    colorOption: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      marginRight: 8,
+    },
+    selectedColor: {
+      borderWidth: 2,
+      borderColor: Colors[colorScheme].text,
+    },
+    notesList: {
+      maxHeight: 120,
+      marginBottom: 12,
+    },
+    noteItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 4,
+    },
+    noteText: {
+      color: Colors[colorScheme].text,
+      flex: 1,
+      marginRight: 6,
+    },
+    addButton: {
+      backgroundColor: Colors[colorScheme].tint,
+      padding: 8,
+      borderRadius: 8,
+      alignItems: 'center',
+      marginBottom: 12,
+    },
+    addButtonText: {
+      color: '#fff',
+    },
+    modalButtons: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    saveButton: {
+      backgroundColor: Colors[colorScheme].tint,
+      padding: 12,
+      borderRadius: 8,
+      flex: 1,
+      marginRight: 8,
+      alignItems: 'center',
+    },
+    cancelButton: {
+      backgroundColor: colorScheme === 'light' ? '#e5e5e5' : '#333',
+      padding: 12,
+      borderRadius: 8,
+      flex: 1,
+      alignItems: 'center',
+    },
+    saveButtonText: {
+      color: '#fff',
+    },
+  });

--- a/app/(tabs)/scholar/_layout.tsx
+++ b/app/(tabs)/scholar/_layout.tsx
@@ -3,19 +3,21 @@ import { createMaterialTopTabNavigator } from '@react-navigation/material-top-ta
 import { Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 const { Navigator } = createMaterialTopTabNavigator();
 const TopTabs = withLayoutContext(Navigator);
 
 export default function ScholarLayout() {
   const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme();
 
   return (
-    <View style={{ flex: 1, backgroundColor: Colors.dark.background }}>
+    <View style={{ flex: 1, backgroundColor: Colors[colorScheme].background }}>
       <View style={{ paddingTop: insets.top + 10, paddingBottom: 10 }}>
         <Text
           style={{
-            color: Colors.dark.text,
+            color: Colors[colorScheme].text,
             textAlign: 'center',
             fontSize: 20,
             fontWeight: 'bold',
@@ -26,10 +28,10 @@ export default function ScholarLayout() {
       </View>
       <TopTabs
         screenOptions={{
-          tabBarActiveTintColor: Colors.dark.tint,
-          tabBarIndicatorStyle: { backgroundColor: Colors.dark.tint },
+          tabBarActiveTintColor: Colors[colorScheme].tint,
+          tabBarIndicatorStyle: { backgroundColor: Colors[colorScheme].tint },
           tabBarStyle: {
-            backgroundColor: Colors.dark.background,
+            backgroundColor: Colors[colorScheme].background,
           },
           tabBarLabelStyle: { marginTop: 10 },
         }}

--- a/app/(tabs)/scholar/curriculum.tsx
+++ b/app/(tabs)/scholar/curriculum.tsx
@@ -1,13 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { ScrollView, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import { subjectData } from '@/constants/subjects';
 import { ibOverview, subjectDetails } from '@/constants/ibInfo';
 import { curriculumUnits } from '@/constants/curriculum';
 
 export default function CurriculumScreen() {
   const [expanded, setExpanded] = useState<string | null>(null);
+  const colorScheme = useColorScheme();
+  const styles = useMemo(() => createStyles(colorScheme), [colorScheme]);
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -23,7 +26,7 @@ export default function CurriculumScreen() {
             <Ionicons
               name={expanded === subject.key ? 'chevron-up' : 'chevron-down'}
               size={16}
-              color={Colors.dark.icon}
+              color={Colors[colorScheme].icon}
               style={styles.chevron}
             />
           </TouchableOpacity>
@@ -44,18 +47,31 @@ export default function CurriculumScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: Colors.dark.background },
-  content: { padding: 16 },
-  overview: { color: Colors.dark.text, marginBottom: 16, fontSize: 16 },
-  card: { backgroundColor: Colors.dark.card, borderRadius: 12, marginBottom: 12 },
-  cardHeader: { flexDirection: 'row', alignItems: 'center', padding: 12 },
-  cardTitle: { color: Colors.dark.text, fontWeight: '600', fontSize: 16 },
-  icon: { marginRight: 8 },
-  chevron: { marginLeft: 'auto' },
-  cardBody: { paddingHorizontal: 12, paddingBottom: 12 },
-  subjectDetail: { color: Colors.dark.text, marginBottom: 8 },
-  unit: { marginBottom: 8 },
-  unitTitle: { color: Colors.dark.tint, fontWeight: '600' },
-  unitDesc: { color: Colors.dark.text, fontSize: 14 },
-});
+const createStyles = (colorScheme: 'light' | 'dark') =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: Colors[colorScheme].background },
+    content: { padding: 16 },
+    overview: {
+      color: Colors[colorScheme].text,
+      marginBottom: 16,
+      fontSize: 16,
+    },
+    card: {
+      backgroundColor: Colors[colorScheme].card,
+      borderRadius: 12,
+      marginBottom: 12,
+    },
+    cardHeader: { flexDirection: 'row', alignItems: 'center', padding: 12 },
+    cardTitle: {
+      color: Colors[colorScheme].text,
+      fontWeight: '600',
+      fontSize: 16,
+    },
+    icon: { marginRight: 8 },
+    chevron: { marginLeft: 'auto' },
+    cardBody: { paddingHorizontal: 12, paddingBottom: 12 },
+    subjectDetail: { color: Colors[colorScheme].text, marginBottom: 8 },
+    unit: { marginBottom: 8 },
+    unitTitle: { color: Colors[colorScheme].tint, fontWeight: '600' },
+    unitDesc: { color: Colors[colorScheme].text, fontSize: 14 },
+  });

--- a/app/(tabs)/scholar/library.tsx
+++ b/app/(tabs)/scholar/library.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 type Book = { key: string; title: string; author_name?: string[] };
 
@@ -16,6 +17,8 @@ export default function LibraryScreen() {
   const [query, setQuery] = useState('');
   const [books, setBooks] = useState<Book[]>([]);
   const [loading, setLoading] = useState(false);
+  const colorScheme = useColorScheme();
+  const styles = useMemo(() => createStyles(colorScheme), [colorScheme]);
 
   const search = async () => {
     if (!query.trim()) return;
@@ -39,7 +42,7 @@ export default function LibraryScreen() {
         <TextInput
           style={styles.input}
           placeholder="Search Open Library"
-          placeholderTextColor={Colors.dark.icon}
+          placeholderTextColor={Colors[colorScheme].icon}
           value={query}
           onChangeText={setQuery}
           onSubmitEditing={search}
@@ -49,7 +52,10 @@ export default function LibraryScreen() {
         </TouchableOpacity>
       </View>
       {loading ? (
-        <ActivityIndicator color={Colors.dark.tint} style={{ marginTop: 20 }} />
+        <ActivityIndicator
+          color={Colors[colorScheme].tint}
+          style={{ marginTop: 20 }}
+        />
       ) : (
         <ScrollView style={styles.results}>
           {books.map(book => (
@@ -66,26 +72,31 @@ export default function LibraryScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: Colors.dark.background, padding: 16 },
-  searchRow: { flexDirection: 'row', marginBottom: 12 },
-  input: {
-    flex: 1,
-    backgroundColor: Colors.dark.card,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    color: Colors.dark.text,
-  },
-  button: {
-    marginLeft: 8,
-    backgroundColor: Colors.dark.tint,
-    borderRadius: 8,
-    paddingHorizontal: 16,
-    justifyContent: 'center',
-  },
-  buttonText: { color: '#fff', fontWeight: '600' },
-  results: { flex: 1 },
-  resultItem: { marginBottom: 12 },
-  resultTitle: { color: Colors.dark.text, fontWeight: '600' },
-  resultAuthor: { color: Colors.dark.icon },
-});
+const createStyles = (colorScheme: 'light' | 'dark') =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].background,
+      padding: 16,
+    },
+    searchRow: { flexDirection: 'row', marginBottom: 12 },
+    input: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].card,
+      borderRadius: 8,
+      paddingHorizontal: 12,
+      color: Colors[colorScheme].text,
+    },
+    button: {
+      marginLeft: 8,
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 8,
+      paddingHorizontal: 16,
+      justifyContent: 'center',
+    },
+    buttonText: { color: '#fff', fontWeight: '600' },
+    results: { flex: 1 },
+    resultItem: { marginBottom: 12 },
+    resultTitle: { color: Colors[colorScheme].text, fontWeight: '600' },
+    resultAuthor: { color: Colors[colorScheme].icon },
+  });

--- a/app/(tabs)/scholar/planner.tsx
+++ b/app/(tabs)/scholar/planner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   ScrollView,
   Text,
@@ -8,11 +8,14 @@ import {
   StyleSheet,
 } from 'react-native';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function PlannerScreen() {
   const [prompt, setPrompt] = useState('');
   const [plan, setPlan] = useState('');
   const [loading, setLoading] = useState(false);
+  const colorScheme = useColorScheme();
+  const styles = useMemo(() => createStyles(colorScheme), [colorScheme]);
 
   const generatePlan = async () => {
     if (!prompt.trim()) return;
@@ -58,7 +61,7 @@ export default function PlannerScreen() {
       <TextInput
         style={styles.input}
         placeholder="Describe what you need help studying..."
-        placeholderTextColor={Colors.dark.icon}
+        placeholderTextColor={Colors[colorScheme].icon}
         value={prompt}
         onChangeText={setPrompt}
         multiline
@@ -66,30 +69,40 @@ export default function PlannerScreen() {
       <TouchableOpacity style={styles.button} onPress={generatePlan}>
         <Text style={styles.buttonText}>Generate Plan</Text>
       </TouchableOpacity>
-      {loading && <ActivityIndicator color={Colors.dark.tint} style={{ marginTop: 20 }} />}
+      {loading && (
+        <ActivityIndicator
+          color={Colors[colorScheme].tint}
+          style={{ marginTop: 20 }}
+        />
+      )}
       {plan ? <Text style={styles.plan}>{plan}</Text> : null}
     </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { padding: 16, backgroundColor: Colors.dark.background, flexGrow: 1 },
-  disclaimer: { color: Colors.dark.text, marginBottom: 12, fontSize: 14 },
-  input: {
-    backgroundColor: Colors.dark.card,
-    color: Colors.dark.text,
-    padding: 12,
-    borderRadius: 8,
-    minHeight: 80,
-    textAlignVertical: 'top',
-  },
-  button: {
-    marginTop: 12,
-    backgroundColor: Colors.dark.tint,
-    borderRadius: 8,
-    paddingVertical: 12,
-    alignItems: 'center',
-  },
-  buttonText: { color: '#fff', fontWeight: '600' },
-  plan: { marginTop: 20, color: Colors.dark.text, fontSize: 14 },
-});
+const createStyles = (colorScheme: 'light' | 'dark') =>
+  StyleSheet.create({
+    container: {
+      padding: 16,
+      backgroundColor: Colors[colorScheme].background,
+      flexGrow: 1,
+    },
+    disclaimer: { color: Colors[colorScheme].text, marginBottom: 12, fontSize: 14 },
+    input: {
+      backgroundColor: Colors[colorScheme].card,
+      color: Colors[colorScheme].text,
+      padding: 12,
+      borderRadius: 8,
+      minHeight: 80,
+      textAlignVertical: 'top',
+    },
+    button: {
+      marginTop: 12,
+      backgroundColor: Colors[colorScheme].tint,
+      borderRadius: 8,
+      paddingVertical: 12,
+      alignItems: 'center',
+    },
+    buttonText: { color: '#fff', fontWeight: '600' },
+    plan: { marginTop: 20, color: Colors[colorScheme].text, fontSize: 14 },
+  });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,27 @@
-import { DarkTheme, ThemeProvider } from '@react-navigation/native';
+import { DefaultTheme, DarkTheme, ThemeProvider as NavigationThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
+
+import { ThemeProvider } from '@/hooks/ThemeContext';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+function RootNavigation() {
+  const colorScheme = useColorScheme();
+  return (
+    <NavigationThemeProvider
+      value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
+    >
+      <Stack initialRouteName="(tabs)">
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+    </NavigationThemeProvider>
+  );
+}
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -17,12 +35,8 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <ThemeProvider value={DarkTheme}>
-        <Stack initialRouteName="(tabs)">
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="light" />
+      <ThemeProvider>
+        <RootNavigation />
       </ThemeProvider>
     </GestureHandlerRootView>
   );

--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -5,9 +5,11 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
+  const colorScheme = useColorScheme();
 
   return (
     <ThemedView>
@@ -19,7 +21,7 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
           name="chevron.right"
           size={18}
           weight="medium"
-          color={Colors.dark.icon}
+          color={Colors[colorScheme].icon}
           style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
         />
 

--- a/hooks/ThemeContext.tsx
+++ b/hooks/ThemeContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { ColorSchemeName } from 'react-native';
+
+interface ThemeContextValue {
+  colorScheme: NonNullable<ColorSchemeName>;
+  toggleColorScheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  colorScheme: 'dark',
+  toggleColorScheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [colorScheme, setColorScheme] = useState<NonNullable<ColorSchemeName>>(
+    'dark',
+  );
+
+  const toggleColorScheme = () =>
+    setColorScheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ colorScheme, toggleColorScheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export { ThemeContext };

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,6 +1,13 @@
-import { useColorScheme as _useColorScheme } from 'react-native';
+import { useTheme } from './ThemeContext';
 
-// Return the device color scheme, defaulting to light when unavailable.
+// Return the current color scheme from context.
 export function useColorScheme() {
-  return _useColorScheme() ?? 'light';
+  const { colorScheme } = useTheme();
+  return colorScheme;
+}
+
+// Hook to toggle between light and dark modes.
+export function useToggleColorScheme() {
+  const { toggleColorScheme } = useTheme();
+  return toggleColorScheme;
 }


### PR DESCRIPTION
## Summary
- Provide a ThemeContext and hooks to toggle light and dark modes
- Wire navigation and tab layouts to respect selected color scheme
- Update Notes, Schedule, and Scholar screens to use dynamic themed styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b72b4aae0c832989d607bbf35ad606