### PR TITLE
feat: add notes shortcut on home screen

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -16,6 +16,7 @@ import AIButton from '@/components/AIButton';
 import { Colors } from '@/constants/Colors';
 import { subjectData, SubjectInfo } from '@/constants/subjects';
 import { useColorScheme, useToggleColorScheme } from '@/hooks/useColorScheme';
+import { useRouter } from 'expo-router';
 
 const cardData = [
   {
@@ -81,6 +82,7 @@ export default function HomeScreen() {
   const { width } = useWindowDimensions();
   const scrollRef = useRef<ScrollView>(null);
   const styles = useMemo(() => createStyles(theme, width), [theme, width]);
+  const router = useRouter();
 
 
   return (
@@ -168,6 +170,19 @@ export default function HomeScreen() {
               <Text style={styles.boxNote}>{section.description}</Text>
             </View>
           ))}
+          <TouchableOpacity
+            style={[styles.notesButton, { backgroundColor: selectedSubject.color }]}
+            onPress={() =>
+              router.push({
+                pathname: '/(tabs)/notes',
+                params: { subject: selectedSubject.key },
+              })
+            }
+          >
+            <Text style={styles.notesButtonText}>
+              Go to {selectedSubject.title} notes
+            </Text>
+          </TouchableOpacity>
         </View>
       </ScrollView>
       <AIButton bottomOffset={20} />
@@ -357,6 +372,18 @@ const createStyles = (
       color: '#ddd',
       fontSize: 14,
       textAlign: 'center',
+    },
+    notesButton: {
+      width: '100%',
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 12,
+      alignItems: 'center',
+    },
+    notesButtonText: {
+      color: '#fff',
+      fontSize: 16,
+      fontWeight: 'bold',
     },
     modalOverlay: {
       flex: 1,

--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -369,7 +369,6 @@ export default function NotesScreen() {
           <View style={styles.boxContent}>
             <Ionicons name={item.icon} size={32} color={iconColor} />
             <Text style={styles.boxTitle}>{item.title}</Text>
-            <Text style={styles.boxNote}>Go to {item.title} notes</Text>
             {item.notes.length > 0 && (
               <Text style={styles.boxNote}>{item.notes.length} notes</Text>
             )}


### PR DESCRIPTION
## Summary
- remove 'Go to subject notes' text from notes screen
- add notes shortcut button on home screen that navigates to selected subject's notes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b730b279d0832998ee5996366f4e6f