### PR TITLE
Improve notes page usability and home styling

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -344,6 +344,8 @@ const createStyles = (
       marginBottom: 12,
       alignItems: 'center',
       position: 'relative',
+      borderWidth: 4,
+      borderColor: '#fff',
     },
     boxTitle: {
       marginTop: 8,


### PR DESCRIPTION
## Summary
- Remove note tags and simplify note model
- Add subject search bar, theme-aware note search, and settings modal to notes
- Outline home page blocks with thick white borders

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74e6403e88329815109aa4f737f9f