### PR TITLE
feat(notes): add full-screen drawing canvas with color and image support

### DIFF
--- a/components/DrawingBoardModal.tsx
+++ b/components/DrawingBoardModal.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { Modal, View, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import DrawingCanvas, { DrawingElement } from './DrawingCanvas';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  elements: DrawingElement[];
+  setElements: (els: DrawingElement[]) => void;
+}
+
+export default function DrawingBoardModal({
+  visible,
+  onClose,
+  elements,
+  setElements,
+}: Props) {
+  const [color, setColor] = useState('#000000');
+  const canvasSize = 2000;
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 1,
+    });
+    if (!result.canceled) {
+      const img = result.assets[0];
+      setElements([
+        ...elements,
+        {
+          type: 'image',
+          uri: img.uri,
+          x: 100,
+          y: 100,
+          width: img.width ?? 200,
+          height: img.height ?? 200,
+        },
+      ]);
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{ flex: 1 }}>
+        <ScrollView
+          horizontal
+          bounces={false}
+          contentContainerStyle={{ width: canvasSize }}
+        >
+          <ScrollView
+            bounces={false}
+            contentContainerStyle={{ height: canvasSize }}
+          >
+            <DrawingCanvas
+              elements={elements}
+              setElements={setElements}
+              strokeColor={color}
+              canvasSize={canvasSize}
+            />
+          </ScrollView>
+        </ScrollView>
+        <View style={styles.toolbar}>
+          {['#000000', '#ff0000', '#00ff00', '#0000ff'].map(c => (
+            <TouchableOpacity
+              key={c}
+              style={[styles.colorDot, { backgroundColor: c }, color === c && styles.selected]}
+              onPress={() => setColor(c)}
+            />
+          ))}
+          <TouchableOpacity onPress={pickImage}>
+            <Ionicons name="image" size={24} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={onClose}>
+            <Ionicons name="checkmark" size={24} color="#fff" />
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  toolbar: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    padding: 10,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+  },
+  colorDot: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    marginHorizontal: 5,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  selected: {
+    borderColor: '#fff',
+  },
+});

--- a/components/DrawingCanvas.tsx
+++ b/components/DrawingCanvas.tsx
@@ -1,36 +1,51 @@
 import React, { useRef, useState } from 'react';
-import { View, PanResponder } from 'react-native';
+import { View, PanResponder, Image } from 'react-native';
+// eslint-disable-next-line import/no-unresolved
 import Svg, { Path } from 'react-native-svg';
 
+export type DrawingElement =
+  | { type: 'path'; d: string; color: string }
+  | { type: 'image'; uri: string; x: number; y: number; width: number; height: number };
+
 interface DrawingCanvasProps {
-  paths: string[];
-  setPaths: (paths: string[]) => void;
+  elements: DrawingElement[];
+  setElements?: (els: DrawingElement[]) => void;
   strokeColor?: string;
   strokeWidth?: number;
+  editable?: boolean;
+  canvasSize?: number;
 }
 
 export default function DrawingCanvas({
-  paths,
-  setPaths,
+  elements,
+  setElements,
   strokeColor = '#000',
   strokeWidth = 4,
+  editable = true,
+  canvasSize = 2000,
 }: DrawingCanvasProps) {
   const [currentPath, setCurrentPath] = useState('');
 
   const panResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponder: () => editable,
       onPanResponderGrant: evt => {
+        if (!editable) return;
         const { locationX, locationY } = evt.nativeEvent;
         setCurrentPath(`M${locationX} ${locationY}`);
       },
       onPanResponderMove: evt => {
+        if (!editable) return;
         const { locationX, locationY } = evt.nativeEvent;
         setCurrentPath(prev => `${prev} L${locationX} ${locationY}`);
       },
       onPanResponderRelease: () => {
-        if (currentPath) {
-          setPaths([...paths, currentPath]);
+        if (!editable) return;
+        if (currentPath && setElements) {
+          setElements([
+            ...elements,
+            { type: 'path', d: currentPath, color: strokeColor },
+          ]);
           setCurrentPath('');
         }
       },
@@ -38,19 +53,39 @@ export default function DrawingCanvas({
   ).current;
 
   return (
-    <View style={{ flex: 1 }} {...panResponder.panHandlers}>
-      <Svg style={{ flex: 1 }}>
-        {paths.map((p, i) => (
-          <Path
-            key={i}
-            d={p}
-            stroke={strokeColor}
-            strokeWidth={strokeWidth}
-            fill="none"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+    <View
+      style={{ width: canvasSize, height: canvasSize }}
+      {...panResponder.panHandlers}
+    >
+      {elements
+        .filter(e => e.type === 'image')
+        .map((img, i) => (
+          <Image
+            key={`img-${i}`}
+            source={{ uri: img.uri }}
+            style={{
+              position: 'absolute',
+              left: img.x,
+              top: img.y,
+              width: img.width,
+              height: img.height,
+            }}
           />
         ))}
+      <Svg style={{ position: 'absolute', width: canvasSize, height: canvasSize }}>
+        {elements
+          .filter(e => e.type === 'path')
+          .map((p, i) => (
+            <Path
+              key={`path-${i}`}
+              d={p.d}
+              stroke={p.color}
+              strokeWidth={strokeWidth}
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
         {currentPath ? (
           <Path
             d={currentPath}


### PR DESCRIPTION
## Summary
- enable full-screen drawing board with scrollable large canvas
- support colored strokes and image insertion in notes
- store drawing elements with color metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b84e777bcc8329b01591668ca28ed4