### PR TITLE
Allow multiple drawing strokes

### DIFF
--- a/components/DrawingBoardModal.tsx
+++ b/components/DrawingBoardModal.tsx
@@ -8,7 +8,7 @@ interface Props {
   visible: boolean;
   onClose: () => void;
   elements: DrawingElement[];
-  setElements: (els: DrawingElement[]) => void;
+  setElements: React.Dispatch<React.SetStateAction<DrawingElement[]>>;
 }
 
 export default function DrawingBoardModal({
@@ -27,8 +27,8 @@ export default function DrawingBoardModal({
     });
     if (!result.canceled) {
       const img = result.assets[0];
-      setElements([
-        ...elements,
+      setElements(prev => [
+        ...prev,
         {
           type: 'image',
           uri: img.uri,

--- a/components/DrawingCanvas.tsx
+++ b/components/DrawingCanvas.tsx
@@ -9,7 +9,7 @@ export type DrawingElement =
 
 interface DrawingCanvasProps {
   elements: DrawingElement[];
-  setElements?: (els: DrawingElement[]) => void;
+  setElements?: React.Dispatch<React.SetStateAction<DrawingElement[]>>;
   strokeColor?: string;
   strokeWidth?: number;
   editable?: boolean;
@@ -25,6 +25,7 @@ export default function DrawingCanvas({
   canvasSize = 2000,
 }: DrawingCanvasProps) {
   const [currentPath, setCurrentPath] = useState('');
+  const currentPathRef = useRef('');
 
   const panResponder = useRef(
     PanResponder.create({
@@ -32,20 +33,25 @@ export default function DrawingCanvas({
       onPanResponderGrant: evt => {
         if (!editable) return;
         const { locationX, locationY } = evt.nativeEvent;
-        setCurrentPath(`M${locationX} ${locationY}`);
+        const path = `M${locationX} ${locationY}`;
+        currentPathRef.current = path;
+        setCurrentPath(path);
       },
       onPanResponderMove: evt => {
         if (!editable) return;
         const { locationX, locationY } = evt.nativeEvent;
-        setCurrentPath(prev => `${prev} L${locationX} ${locationY}`);
+        const path = `${currentPathRef.current} L${locationX} ${locationY}`;
+        currentPathRef.current = path;
+        setCurrentPath(path);
       },
       onPanResponderRelease: () => {
         if (!editable) return;
-        if (currentPath && setElements) {
-          setElements([
-            ...elements,
-            { type: 'path', d: currentPath, color: strokeColor },
+        if (currentPathRef.current && setElements) {
+          setElements(prev => [
+            ...prev,
+            { type: 'path', d: currentPathRef.current, color: strokeColor },
           ]);
+          currentPathRef.current = '';
           setCurrentPath('');
         }
       },


### PR DESCRIPTION
## Summary
- allow multiple strokes to be added to drawing canvas
- ensure drawing save uses functional state updates so work isn't lost

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87942789483298e3a418e32ea492b