### PR TITLE
Improve drawing responsiveness and add tool size options

### DIFF
--- a/components/DrawingBoardModal.tsx
+++ b/components/DrawingBoardModal.tsx
@@ -19,7 +19,9 @@ export default function DrawingBoardModal({
 }: Props) {
   const [color, setColor] = useState('#000000');
   const [eraser, setEraser] = useState(false);
+  const [strokeWidth, setStrokeWidth] = useState(4);
   const COLORS = ['#000000', '#ff0000', '#0000ff', '#008000'];
+  const SIZES = [4, 8, 12, 16];
   const canvasSize = 2000;
 
   const pickImage = async () => {
@@ -59,8 +61,8 @@ export default function DrawingBoardModal({
               elements={elements}
               setElements={setElements}
               strokeColor={eraser ? '#ffffff' : color}
+              strokeWidth={strokeWidth}
               canvasSize={canvasSize}
-              eraser={eraser}
             />
           </ScrollView>
         </ScrollView>
@@ -77,6 +79,24 @@ export default function DrawingBoardModal({
                   },
                 ]}
                 onPress={() => setColor(c)}
+              />
+            ))}
+          </View>
+          <View style={styles.sizePalette}>
+            {SIZES.map(s => (
+              <TouchableOpacity
+                key={s}
+                style={[
+                  styles.sizeSwatch,
+                  {
+                    width: s,
+                    height: s,
+                    borderRadius: s / 2,
+                    backgroundColor: '#fff',
+                    borderColor: s === strokeWidth ? '#fff' : 'transparent',
+                  },
+                ]}
+                onPress={() => setStrokeWidth(s)}
               />
             ))}
           </View>
@@ -113,6 +133,13 @@ const styles = StyleSheet.create({
   },
   colorPalette: {
     flexDirection: 'row',
+  },
+  sizePalette: {
+    flexDirection: 'row',
+  },
+  sizeSwatch: {
+    marginHorizontal: 4,
+    borderWidth: 2,
   },
   colorSwatch: {
     width: 30,

--- a/components/DrawingCanvas.tsx
+++ b/components/DrawingCanvas.tsx
@@ -14,7 +14,6 @@ interface DrawingCanvasProps {
   strokeWidth?: number;
   editable?: boolean;
   canvasSize?: number;
-  eraser?: boolean;
 }
 
 export default function DrawingCanvas({
@@ -24,7 +23,6 @@ export default function DrawingCanvas({
   strokeWidth = 4,
   editable = true,
   canvasSize = 2000,
-  eraser = false,
 }: DrawingCanvasProps) {
   const [currentPath, setCurrentPath] = useState('');
   const pointsRef = useRef<{ x: number; y: number }[]>([]);
@@ -89,6 +87,7 @@ export default function DrawingCanvas({
           );
         } else {
           pointsRef.current.push({ x: locationX, y: locationY });
+          setCurrentPath(lineGenerator(pointsRef.current) ?? '');
         }
       },
       onPanResponderRelease: () => {
@@ -99,7 +98,7 @@ export default function DrawingCanvas({
         }
         if (pointsRef.current.length && setElements) {
           const path = lineGenerator(pointsRef.current) ?? '';
-          const width = eraser ? 20 : strokeWidthRef.current;
+          const width = strokeWidthRef.current;
           setElements(prev => [
             ...prev,
             { type: 'path', d: path, color: strokeColorRef.current, width },
@@ -110,23 +109,6 @@ export default function DrawingCanvas({
       },
     }),
   ).current;
-
-  useEffect(() => {
-    let frameId: number;
-    const interval = 1000 / 120;
-    let last = 0;
-    const frame = (time: number) => {
-      if (time - last >= interval) {
-        if (pointsRef.current.length) {
-          setCurrentPath(lineGenerator(pointsRef.current) ?? '');
-        }
-        last = time;
-      }
-      frameId = requestAnimationFrame(frame);
-    };
-    frameId = requestAnimationFrame(frame);
-    return () => cancelAnimationFrame(frameId);
-  }, [lineGenerator]);
 
   return (
     <View
@@ -166,7 +148,7 @@ export default function DrawingCanvas({
           <Path
             d={currentPath}
             stroke={strokeColor}
-            strokeWidth={eraser ? 20 : strokeWidth}
+            strokeWidth={strokeWidth}
             fill="none"
             strokeLinecap="round"
             strokeLinejoin="round"


### PR DESCRIPTION
## Summary
- remove drawing frame delay for smoother strokes
- allow eraser to share adjustable stroke width
- add toolbar controls for brush sizes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88cfcc1248329aa738c631546d263