### PR TITLE
feat: implement stroke eraser

### DIFF
--- a/components/DrawingBoardModal.tsx
+++ b/components/DrawingBoardModal.tsx
@@ -60,9 +60,10 @@ export default function DrawingBoardModal({
             <DrawingCanvas
               elements={elements}
               setElements={setElements}
-              strokeColor={eraser ? '#ffffff' : color}
+              strokeColor={color}
               strokeWidth={strokeWidth}
               canvasSize={canvasSize}
+              eraser={eraser}
             />
           </ScrollView>
         </ScrollView>


### PR DESCRIPTION
## Summary
- add eraser mode that deletes path elements instead of drawing white strokes
- pass eraser flag from drawing board modal and keep stroke color intact

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88f0df9808329b9d5c300b17991bf