### PR TITLE
Fix drawing canvas layering for text input and image movement

### DIFF
--- a/components/DrawingCanvas.tsx
+++ b/components/DrawingCanvas.tsx
@@ -318,6 +318,34 @@ export default function DrawingCanvas({
       style={{ width: canvasSize, height: canvasSize }}
       {...panResponder.panHandlers}
     >
+      <Svg
+        pointerEvents="none"
+        style={{ position: 'absolute', width: canvasSize, height: canvasSize }}
+      >
+        {elements
+          .filter(e => e.type === 'path')
+          .map((p, i) => (
+            <Path
+              key={`path-${i}`}
+              d={p.d}
+              stroke={p.color}
+              strokeWidth={p.width ?? strokeWidth}
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
+        {currentPath ? (
+          <Path
+            d={currentPath}
+            stroke={strokeColor}
+            strokeWidth={strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ) : null}
+      </Svg>
       {elements
         .filter(e => e.type === 'image')
         .map((img, i) => (
@@ -401,31 +429,6 @@ export default function DrawingCanvas({
             </Text>
           )
         ))}
-      <Svg style={{ position: 'absolute', width: canvasSize, height: canvasSize }}>
-        {elements
-          .filter(e => e.type === 'path')
-          .map((p, i) => (
-            <Path
-              key={`path-${i}`}
-              d={p.d}
-              stroke={p.color}
-              strokeWidth={p.width ?? strokeWidth}
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          ))}
-        {currentPath ? (
-          <Path
-            d={currentPath}
-            stroke={strokeColor}
-            strokeWidth={strokeWidth}
-            fill="none"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        ) : null}
-      </Svg>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- Move SVG drawing layer behind images and text
- Disable SVG touch handling so text boxes accept input without glitches
- Keep images and text above drawing for easier selection and dragging

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba1959cc5083298c063d3823466d01