### PR TITLE
fix: preserve note text input

### DIFF
--- a/app/(tabs)/notes.tsx
+++ b/app/(tabs)/notes.tsx
@@ -130,6 +130,7 @@ export default function NotesScreen() {
     });
     setDraftTitle('');
     setDraftContent('');
+    richText.current?.setContentHTML('');
     setTextColor('#000000');
     richText.current?.setForeColor('#000000');
   };
@@ -156,6 +157,7 @@ export default function NotesScreen() {
       setDrawingModalVisible(true);
     } else {
       setDraftContent(note.content);
+      richText.current?.setContentHTML(note.content);
       setTextColor('#000000');
       richText.current?.setForeColor('#000000');
     }
@@ -180,6 +182,7 @@ export default function NotesScreen() {
     setEditingNote(null);
     setDraftTitle('');
     setDraftContent('');
+    richText.current?.setContentHTML('');
     setDrawingElements([]);
     setDrawingModalVisible(false);
   };
@@ -188,6 +191,7 @@ export default function NotesScreen() {
     setEditingNote(null);
     setDraftTitle('');
     setDraftContent('');
+    richText.current?.setContentHTML('');
     setDrawingElements([]);
     setTextColor('#000000');
     setDrawingModalVisible(false);
@@ -476,7 +480,6 @@ export default function NotesScreen() {
             />
             <RichEditor
               ref={richText}
-              initialContentHTML={draftContent}
               onChange={setDraftContent}
               placeholder="Start writing..."
               editorStyle={{ color: textColor }}


### PR DESCRIPTION
## Summary
- prevent note editor from clearing typed content by managing RichEditor content via setContentHTML and removing dynamic initialContentHTML

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba1aa95ee0832985b5528f242dd1ee