### PR TITLE
Add Babel configuration for Expo Router and Reanimated

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel', 'react-native-reanimated/plugin'],
+  };
+};


### PR DESCRIPTION
## Summary
- add a Babel configuration file that enables the expo-router and react-native-reanimated plugins so the runtime can load the Reanimated module correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e410d259b0832981c8761ed08677c8